### PR TITLE
FH-4454 use type instead of timestamp for unique app name

### DIFF
--- a/pkg/cmd/clients.go
+++ b/pkg/cmd/clients.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	"io"
 
@@ -130,7 +129,7 @@ oc plugin mobile create client <name> <clientType>
 				app.Labels["icon"] = "icon-cordova"
 				break
 			}
-			app.Name = name + "-" + fmt.Sprintf("%v", time.Now().Unix())
+			app.Name = name + "-" + app.Spec.ClientType
 			if err := input.ValidateMobileClient(app); err != nil {
 				return errors.Wrap(err, "Failed validation while creating new mobile client")
 			}


### PR DESCRIPTION
# Motivation

Use client type instead of timestamp to create a unique app name. This makes it possible to construct the unique app name when only the `spec.name` is known. Use case: the deprovision script of a APB.

You won't be able to create two Apps of the same type with the same name. But you can still use the same app name for different client types:

```
⇒  mobile create client app android --namespace=myproject
⇒  mobile get clients --namespace=myproject
+-------------+------+------------+
|     ID      | NAME | CLIENTTYPE |
+-------------+------+------------+
| app-android | app  | android    |
| app-cordova | app  | cordova    |
+-------------+------+------------+
```