### PR TITLE
Allow for a cluster service classes dependencies field

### DIFF
--- a/pkg/cmd/services.go
+++ b/pkg/cmd/services.go
@@ -72,9 +72,9 @@ func (sc *ServicesCmd) ListServicesCmd() *cobra.Command {
 		var data [][]string
 		for _, item := range scL.Items {
 			extMeta := item.Spec.ExternalMetadata.Raw
-			extMap := map[string]string{}
-			json.Unmarshal(extMeta, &extMap)
-			data = append(data, []string{item.Spec.ExternalName, extMap["serviceName"], extMap["integrations"], item.Name})
+			extServiceClass := map[string]string{}
+			json.Unmarshal(extMeta, &extServiceClass)
+			data = append(data, []string{item.Spec.ExternalName, extServiceClass["serviceName"], extServiceClass["integrations"], item.Name})
 		}
 		table := tablewriter.NewWriter(writer)
 		table.AppendBulk(data)
@@ -96,12 +96,12 @@ func findServiceClassByName(scClient versioned.Interface, name string) (*v1beta1
 	}
 
 	for _, item := range mobileServices.Items {
-		var extData map[string]string
+		var extData ServiceClass
 		rawData := item.Spec.ExternalMetadata.Raw
 		if err := json.Unmarshal(rawData, &extData); err != nil {
 			return nil, err
 		}
-		if extData["serviceName"] == name {
+		if extData.ServiceName == name {
 			return &item, nil
 		}
 	}
@@ -179,8 +179,8 @@ func (sc *ServicesCmd) ProvisionServiceCmd() *cobra.Command {
 			validServiceName := clusterServiceClass.Spec.ExternalName
 			sid := uuid.NewV4().String()
 			extMeta := clusterServiceClass.Spec.ExternalMetadata.Raw
-			extMap := map[string]string{}
-			if err := json.Unmarshal(extMeta, &extMap); err != nil {
+			var extServiceClass ServiceClass
+			if err := json.Unmarshal(extMeta, &extServiceClass); err != nil {
 				return err
 			}
 
@@ -190,7 +190,7 @@ func (sc *ServicesCmd) ProvisionServiceCmd() *cobra.Command {
 					Kind:       "ServiceInstance",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:       map[string]string{"id": sid, "serviceName": extMap["serviceName"]},
+					Labels:       map[string]string{"id": sid, "serviceName": extServiceClass.ServiceName},
 					Namespace:    ns,
 					GenerateName: validServiceName + "-",
 				},

--- a/pkg/cmd/services.go
+++ b/pkg/cmd/services.go
@@ -96,7 +96,7 @@ func findServiceClassByName(scClient versioned.Interface, name string) (*v1beta1
 	}
 
 	for _, item := range mobileServices.Items {
-		var extData ServiceClass
+		var extData ExternalServiceMetaData
 		rawData := item.Spec.ExternalMetadata.Raw
 		if err := json.Unmarshal(rawData, &extData); err != nil {
 			return nil, err
@@ -179,7 +179,7 @@ func (sc *ServicesCmd) ProvisionServiceCmd() *cobra.Command {
 			validServiceName := clusterServiceClass.Spec.ExternalName
 			sid := uuid.NewV4().String()
 			extMeta := clusterServiceClass.Spec.ExternalMetadata.Raw
-			var extServiceClass ServiceClass
+			var extServiceClass ExternalServiceMetaData
 			if err := json.Unmarshal(extMeta, &extServiceClass); err != nil {
 				return err
 			}

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -29,6 +29,15 @@ type Service struct {
 	Writable     bool                           `json:"writable"`
 }
 
+type ServiceClass struct {
+	Dependencies        []string `json:"dependencies"`
+	DisplayName         string   `json:"displayName"`
+	DocumentationURL    string   `json:"documentationUrl"`
+	ImageURL            string   `json:"imageUrl"`
+	ProviderDisplayName string   `json:"providerDisplayName"`
+	ServiceName         string   `json:"serviceName"`
+}
+
 type ServiceIntegration struct {
 	Enabled         bool   `json:"enabled"`
 	Component       string `json:"component"`

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -29,7 +29,7 @@ type Service struct {
 	Writable     bool                           `json:"writable"`
 }
 
-type ServiceClass struct {
+type ExternalServiceMetaData struct {
 	Dependencies        []string `json:"dependencies"`
 	DisplayName         string   `json:"displayName"`
 	DocumentationURL    string   `json:"documentationUrl"`


### PR DESCRIPTION
Currently we unmarshal the cluster service class JSON response into
a map[string]string. However, cluster service classes can also have
a dependencies field which is an array of strings. This causes every
provision to fail as the unmarshalling fails.

This change adds a ServiceClass struct instead of the map[string]string.

The current error while running:
```
oc plugin mobile create serviceinstance keycloak --namespace=noop
```

```
Error: failed to find a service class associated with that name json: cannot unmarshal array into Go value of type string
```