### PR TITLE
metadata names must be lowercase

### DIFF
--- a/pkg/cmd/clients.go
+++ b/pkg/cmd/clients.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-
+	"strings"
 	"io"
 
 	"github.com/aerogear/mobile-cli/pkg/apis/mobile/v1alpha1"
@@ -129,7 +129,7 @@ oc plugin mobile create client <name> <clientType>
 				app.Labels["icon"] = "icon-cordova"
 				break
 			}
-			app.Name = name + "-" + app.Spec.ClientType
+			app.Name = name + "-" + strings.ToLower(app.Spec.ClientType)
 			if err := input.ValidateMobileClient(app); err != nil {
 				return errors.Wrap(err, "Failed validation while creating new mobile client")
 			}


### PR DESCRIPTION
Metadata names must be lowercase, otherwise the kubernetes client returns the following error when trying to use the `iOS` type:

```
⇒  mobile create client app iOS --namespace=myproject
Error: failed to create mobile client: MobileClient.mobile.k8s.io "app-iOS" is invalid: metadata.name: Invalid value: "app-iOS": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```