### PR TITLE
goreleaser integration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,14 @@
+# .goreleaser.yml
+# Build customization
+builds:
+  - binary: om
+    main: ./cmd/mobile/main.go
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+archive:
+  format: tar.gz
+  

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 # .goreleaser.yml
 # Build customization
 builds:
-  - binary: om
+  - binary: mobile
     main: ./cmd/mobile/main.go
     goos:
       - windows


### PR DESCRIPTION
Suggested binary name: `om` - It doesn't seem to be taken by any existing yum/apt package.
 
Tag created: https://github.com/aerogear/mobile-cli/releases/tag/v0.0.1
You can test that by executing: `goreleaser`

