### PR TITLE
Add Help to each available root commands

### DIFF
--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -21,10 +21,10 @@ import (
 func NewCreateCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "create",
-		Short: "create clients integrations etc...",
+		Short: "create clients, integrations, etc...",
 		Long:  `create allows you to do things such as create clients, clientbuilds and service bindings etc`,
 		Run: func(cmd *cobra.Command, args []string) {
-
+			cmd.Help()
 		},
 	}
 }

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -23,7 +23,7 @@ func NewDeleteComand() *cobra.Command {
 		Use:   "delete",
 		Short: "delete clients, clientbuilds etc",
 		Run: func(cmd *cobra.Command, args []string) {
-
+			cmd.Help()
 		},
 	}
 }

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -22,10 +22,8 @@ func NewGetCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "get",
 		Short: "get clients, service and clientbuilds",
-
 		Run: func(cmd *cobra.Command, args []string) {
-
+			cmd.Help()
 		},
 	}
-
 }

--- a/pkg/cmd/start.go
+++ b/pkg/cmd/start.go
@@ -8,8 +8,8 @@ func NewStartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "start",
 		Short: "start clientbuild",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
 		},
 	}
 }

--- a/pkg/cmd/stop.go
+++ b/pkg/cmd/stop.go
@@ -8,8 +8,8 @@ func NewStopCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "stop",
 		Short: "stop clientbuild",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
 		},
 	}
 }


### PR DESCRIPTION
## Description
Added [cmd.Help()](https://godoc.org/github.com/spf13/cobra#Command.Help) to display the command description when a root command (create, get, stop, start, delete) is ran. 