### PR TITLE
Fixes for the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,13 @@ node ("go") {
       }
       
       stage ("Run") {
-        sh "./main"  
+        // workaround because of the https://issues.jboss.org/browse/FH-4471 
+        sh "mkdir -p /home/jenkins/.kube"
+        sh "rm /home/jenkins/.kube/config || true"
+        sh "oc config view > /home/jenkins/.kube/config"
+        //end of workaround
+
+        sh "./mobile"  
       }
     }
   }


### PR DESCRIPTION
There was a typo in the Run stage, when I ran ./main instead of ./mobile
There needed to be another workaround because of https://issues.jboss.org/browse/FH-4471