### PR TITLE
add script to perform the client generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,7 @@ build_linux:
 	env GOOS=linux GOARCH=amd64 go build -o mobile ./cmd/mobile
 
 generate:
-	cp -R ./external/k8s.io/code-generator ./vendor/k8s.io/code-generator
-	vendor/k8s.io/code-generator/generate-internal-groups.sh client github.com/aerogear/mobile-cli/pkg/client/mobile github.com/aerogear/mobile-cli/pkg/apis github.com/aerogear/mobile-cli/pkg/apis  "mobile:v1alpha1"
-	vendor/k8s.io/code-generator/generate-internal-groups.sh client github.com/aerogear/mobile-cli/pkg/client/servicecatalog github.com/aerogear/mobile-cli/pkg/apis github.com/aerogear/mobile-cli/pkg/apis  "servicecatalog:v1beta1"
-	rm -rf vendor/k8s.io/code-generator
+	./scripts/generate.sh
 
 test-unit:
 	@echo Running tests:

--- a/external/README.md
+++ b/external/README.md
@@ -1,2 +1,0 @@
-The code generator comes from https://github.com/kubernetes/code-generator and is based from the release-1.8 branch
-to update checkout the branch you want and copy to this directory

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+k8=$GOPATH/src/k8s.io
+code_gen=${k8}/code-generator
+
+
+if [ ! -d ${code_gen} ]; then
+   mkdir -p ${k8} && cd $k8 && git clone git@github.com:kubernetes/code-generator.git
+fi
+
+cd ${code_gen} && git checkout release-1.8
+
+cd ${code_gen}
+./generate-internal-groups.sh client github.com/aerogear/mobile-cli/pkg/client/mobile github.com/aerogear/mobile-cli/pkg/apis github.com/aerogear/mobile-cli/pkg/apis  "mobile:v1alpha1"
+./generate-internal-groups.sh client github.com/aerogear/mobile-cli/pkg/client/servicecatalog github.com/aerogear/mobile-cli/pkg/apis github.com/aerogear/mobile-cli/pkg/apis  "servicecatalog:v1beta1"


### PR DESCRIPTION
The clients we use are generated using the same process k8s uses, if we make changes to any of our api types we will need to be able to regenerate our clients. This pr adds in a make generate command and supporting script