### PR TITLE
Parse valid and formatted client config

### DIFF
--- a/pkg/cmd/clientConfig.go
+++ b/pkg/cmd/clientConfig.go
@@ -43,6 +43,7 @@ mobile --namespace=myproject get clientconfig
 kubectl plugin mobile get clientconfig`,
 		Run: func(cmd *cobra.Command, args []string) {
 			ret := []*ServiceConfig{}
+
 			convertors := map[string]SecretConvertor{
 				"fh-sync-server": &syncSecretConvertor{},
 				"keycloak":       &keycloakSecretConvertor{},
@@ -71,8 +72,15 @@ kubectl plugin mobile get clientconfig`,
 				}
 				ret = append(ret, svcConifg)
 			}
+
+			outputJSON := ServiceConfigs{
+				Services: ret,
+				Name:     namespace,
+			}
+
 			encoder := json.NewEncoder(os.Stdout)
-			if err := encoder.Encode(ret); err != nil {
+			encoder.SetIndent("", "  ")
+			if err := encoder.Encode(outputJSON); err != nil {
 				log.Fatal("failed to encode sdk config ", err)
 			}
 

--- a/pkg/cmd/clientConfig.go
+++ b/pkg/cmd/clientConfig.go
@@ -74,8 +74,8 @@ kubectl plugin mobile get clientconfig`,
 			}
 
 			outputJSON := ServiceConfigs{
-				Services: ret,
-				Namespace:     namespace,
+				Services:  ret,
+				Namespace: namespace,
 			}
 
 			encoder := json.NewEncoder(os.Stdout)

--- a/pkg/cmd/clientConfig.go
+++ b/pkg/cmd/clientConfig.go
@@ -75,7 +75,7 @@ kubectl plugin mobile get clientconfig`,
 
 			outputJSON := ServiceConfigs{
 				Services: ret,
-				Name:     namespace,
+				Namespace:     namespace,
 			}
 
 			encoder := json.NewEncoder(os.Stdout)

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -62,8 +62,8 @@ type SecretConvertor interface {
 }
 
 type ServiceConfigs struct {
-	Services []*ServiceConfig `json:"services"`
-	Namespace     string           `json:"namespace"`
+	Services  []*ServiceConfig `json:"services"`
+	Namespace string           `json:"namespace"`
 }
 
 type ServiceConfig struct {

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -61,6 +61,11 @@ type SecretConvertor interface {
 	Convert(s *Service) (*ServiceConfig, error)
 }
 
+type ServiceConfigs struct {
+	Services []*ServiceConfig `json:"services"`
+	Name     string           `json:"name"`
+}
+
 type ServiceConfig struct {
 	Config map[string]interface{} `json:"config"`
 	Name   string                 `json:"name"`

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -63,7 +63,7 @@ type SecretConvertor interface {
 
 type ServiceConfigs struct {
 	Services []*ServiceConfig `json:"services"`
-	Name     string           `json:"name"`
+	Namespace     string           `json:"namespace"`
 }
 
 type ServiceConfig struct {


### PR DESCRIPTION
## Motivation

`[]` type string is valid json but it's antipattern for json output and may cause issues in future.
Additionally added formatting for json output so it's easy to read that.

New format: https://gist.github.com/wtrocki/01f3956676bc10933770d8973bd395b5