### PR TITLE
[AEROGEAR-1856] Review command for mobile client creation

### DIFF
--- a/pkg/cmd/clients.go
+++ b/pkg/cmd/clients.go
@@ -110,7 +110,7 @@ This is used to provide a mobile client context for various actions such as crea
 
 The available client types are android, cordova and iOS. 
 
-A namespace must be specified by providing the --namespace flag or by setting the KUBECTL_PLUGINS_CURRENT_NAMESPACE environment variable.`,
+When used standalone, a namespace must be specified by providing the --namespace flag.`,
 		Example: `  mobile create client <name> <clientType> --namespace=myproject 
   kubectl plugin mobile create client <name> <clientType>
   oc plugin mobile create client <name> <clientType>`,

--- a/pkg/cmd/clients.go
+++ b/pkg/cmd/clients.go
@@ -105,15 +105,18 @@ func (cc *ClientCmd) CreateClientCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "client <name> <clientType iOS|cordova|android>",
 		Short: "create a mobile client representation in your namespace",
-		Long: `Sets up the representation of a mobile application in your namespace. This used to provide a mobile client context for various
-actions such as doing mobile client builds,
-mobile --namespace=myproject create client <name> <clientType>
-kubectl plugin mobile create client <name> <clientType>
-oc plugin mobile create client <name> <clientType>
-`,
+		Long: `Sets up the representation of a mobile application of the specified type in your namespace.
+This is used to provide a mobile client context for various actions such as creating, starting or stopping mobile client builds.
+
+The available client types are android, cordova and iOS. 
+
+A namespace must be specified by providing the --namespace flag or by setting the KUBECTL_PLUGINS_CURRENT_NAMESPACE environment variable.`,
+		Example: `  mobile create client <name> <clientType> --namespace=myproject 
+  kubectl plugin mobile create client <name> <clientType>
+  oc plugin mobile create client <name> <clientType>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {
-				return errors.New("expected a name and clientType " + cmd.Use)
+				return errors.New("expected a name and a clientType")
 			}
 			name := args[0]
 			clientType := args[1]

--- a/pkg/cmd/clients_test.go
+++ b/pkg/cmd/clients_test.go
@@ -384,40 +384,6 @@ func TestCreateClient(t *testing.T) {
 			},
 		},
 		{
-			Name: "test create cordova mobile client succeeds without error",
-			Args: []string{"test", "cordova"},
-			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
-					ca := action.(kt.CreateAction)
-					return true, ca.GetObject(), nil
-				})
-				return mc
-			},
-			Flags: []string{"--namespace=myproject", "-o=json"},
-			Validate: func(t *testing.T, c *v1alpha1.MobileClient) {
-				if nil == c {
-					t.Fatal("expected a mobile client but got nil")
-				}
-				if c.Spec.ClientType != "cordova" {
-					t.Fatal("expected the clientType to be cordova but got ", c.Spec.ClientType)
-				}
-				if c.Spec.Name != "test" {
-					t.Fatal("expected the client name to be test but got ", c.Spec.Name)
-				}
-				if c.Spec.ApiKey == "" {
-					t.Fatal("expected an apiKey to be generated but it was empty")
-				}
-				icon, ok := c.Labels["icon"]
-				if !ok {
-					t.Fatal("expected an icon to be set but there was none")
-				}
-				if icon != "icon-cordova" {
-					t.Fatal("expected the icon to be icon-cordova but got ", icon)
-				}
-			},
-		},
-		{
 			Name:         "test create mobile client fails with unknown client type",
 			Args:         []string{"test", "firefox"},
 			ExpectError:  true,
@@ -432,9 +398,10 @@ func TestCreateClient(t *testing.T) {
 			Flags: []string{"--namespace=myproject", "-o=json"},
 		},
 		{
-			Name:        "test create mobile client fails when missing required arguments",
-			Args:        []string{"test"},
-			ExpectError: true,
+			Name:         "test create mobile client fails when missing required arguments",
+			Args:         []string{"test"},
+			ExpectError:  true,
+			ErrorPattern: "^expected a name and a clientType",
 			MobileClient: func() mc.Interface {
 				mc := &mcFake.Clientset{}
 				mc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
@@ -448,7 +415,7 @@ func TestCreateClient(t *testing.T) {
 			Name:         "test create mobile client fails with clear error message",
 			Args:         []string{"test", "cordova"},
 			ExpectError:  true,
-			ErrorPattern: "^failed to create mobile client:.*",
+			ErrorPattern: "^failed to create mobile client: something went wrong",
 			MobileClient: func() mc.Interface {
 				mc := &mcFake.Clientset{}
 				mc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {


### PR DESCRIPTION
## Description
Users must be able to create a representation of a mobile app (Native Android, Native iOS & Cordova) via the CLI. The current create command must be reviewed and ensure it has proper documentation and tests. 

## Tasks
- [x] Review the current command code
- [x] Ensure the documentation of the command is up to date and clear
- [x] Ensure there is a set of good and clear unit tests
- [x] Ensure that client representations (cordova, iOS and android) can be created

## Related Notes
JIRA Ticket - https://issues.jboss.org/browse/AEROGEAR-1856