### PR TITLE
🔒 Require approval for PRs from untrusted sources

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -45,13 +45,16 @@ There are a few things you should keep in mind before creating a PR.
 
 * You Must run ```make build``` before creating the PR and ensure it must execute with no errors.
 
-* When needed provide an explanation of the command and the expected output to help others that may review and test the change.
+* When needed, provide an explanation of the command and the expected output to help others that may review and test the change.
 
 === Making a pull request
 
 Make a https://help.github.com/articles/using-pull-requests[pull request (PR)] in the standard way.
 
 Use [WIP] at the beginning of the title (ie. [WIP] Add feature to the CLI) to mark a PR as a Work in Progress.
+
+If you are not a member of the https://github.com/aerogear[aerogear org], the build job will pause for approval from a trusted approver.
+Anyone who can login to Jenkins can approve.
 
 Your PR will then be reviewed, questions may be asked and changes requested.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,12 @@
+#!groovy
+
+// https://github.com/feedhenry/fh-pipeline-library
+@Library('fh-pipeline-library') _
+
+stage('Trust') {
+    enforceTrustedApproval('aerogear')
+}
+
 node ("go") {
   sh "mkdir -p src/github.com/aerogear/mobile-cli"
   withEnv(["GOPATH=${env.WORKSPACE}/","PATH=${env.PATH}:${env.WORKSPACE}/bin"]) {
@@ -5,25 +14,24 @@ node ("go") {
       stage("Checkout") {
         checkout scm
       }
-      
+
       stage ("Setup") {
         sh "glide install"
       }
-      
+
       stage ("Build") {
         sh "make build"
       }
-      
+
       stage ("Run") {
-        // workaround because of the https://issues.jboss.org/browse/FH-4471 
+        // workaround because of the https://issues.jboss.org/browse/FH-4471
         sh "mkdir -p /home/jenkins/.kube"
         sh "rm /home/jenkins/.kube/config || true"
         sh "oc config view > /home/jenkins/.kube/config"
         //end of workaround
 
-        sh "./mobile"  
+        sh "./mobile"
       }
     }
   }
 }
-


### PR DESCRIPTION
This initial step should not have any impact on PRs from people who
are members of the aerogear org, or for non-PR builds from this
Jenkinsfile.

For contributors who are not members of the aerogear org, PRs will
hang at this step, waiting for someone to approve. Only people who can
authenticate to the Jenkins instance will be able to approve --
currently that means 'members of the fheng org'.

This is intended as a safety measure to help prevent potential attacks
on our build infrastructure, by executing arbitrary code there through
pull requests.