### PR TITLE
Proof of concept integration tests cli client commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,8 @@ fmt:
 check: errcheck vet fmt test-unit
 
 .PHONY: integration
-integration:
-	go build -o mobile ./cmd/mobile
-	go test ./integration
+integration: build
+	go test -v ./integration -args -namespace=`oc project -q` -executable=`pwd`/mobile
 
 .PHONY: release
 release: setup

--- a/integration/client_crudl_test.go
+++ b/integration/client_crudl_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os/exec"
+	"testing"
+)
+
+var namespace = flag.String("namespace", "", "Openshift namespace (most often Project) to run our integration tests in")
+var name = flag.String("name", "", "Client name to be created")
+var executable = flag.String("executable", "", "Executable under test")
+
+type MobileClientSpec struct {
+	Name       string
+	ApiKey     string
+	ClientType string
+}
+
+type MobileClientJson struct {
+	Spec MobileClientSpec
+}
+
+func TestPositive(t *testing.T) {
+
+	actions := []struct {
+		Name     string
+		Args     func(clientType string) []string
+		Validate func(clientType string, output []byte)
+	}{
+		{
+			Name: "Create",
+			Args: func(clientType string) []string {
+				return []string{"create", "client", *name, clientType}
+			},
+			Validate: func(clientType string, output []byte) {
+				var parsed MobileClientJson
+				errJson := json.Unmarshal([]byte(output), &parsed)
+				if errJson != nil {
+					t.Fatal(errJson)
+				}
+				if parsed.Spec.ClientType != clientType {
+					t.Fatal(fmt.Sprintf("Expected the ClientType to be %s, but got %s", clientType, parsed.Spec.ClientType))
+				}
+				if parsed.Spec.Name != *name {
+					t.Fatal(fmt.Sprintf("Expected the Name to be %s, but got %s", *name, parsed.Spec.Name))
+				}
+			},
+		},
+		/*{
+			Name: "Get",
+			Args: func(clientType string) []string {
+				return []string{"get", "client", fmt.Sprintf("%s-%s", *name, clientType)}
+			},
+			Validate: func(clientType string, output []byte) {
+				var parsed MobileClientJson
+				errJson := json.Unmarshal([]byte(output), &parsed)
+				if errJson != nil {
+					t.Fatal(errJson)
+				}
+				if parsed.Spec.ClientType != clientType {
+					t.Fatal(fmt.Sprintf("Expected the ClientType to be %s, but got %s", clientType, parsed.Spec.ClientType))
+				}
+				if parsed.Spec.Name != *name {
+					t.Fatal(fmt.Sprintf("Expected the Name to be %s, but got %s", *name, parsed.Spec.Name))
+				}
+			},
+		},
+		{
+			Name: "Delete",
+		},*/
+	}
+
+	clientTypes := []string{
+		"cordova",
+		"iOS",
+		"android",
+	}
+
+	for _, clientType := range clientTypes {
+		for _, action := range actions {
+			t.Run(fmt.Sprintf("%s/%s", clientType, action.Name), func(t *testing.T) {
+				args := append(action.Args(clientType), fmt.Sprintf("--namespace=%s", *namespace), "-o=json")
+				cmd := exec.Command(*executable, args...)
+				output, errCommand := cmd.CombinedOutput()
+				t.Log(fmt.Sprintf("%s\n", output))
+				if errCommand != nil {
+					t.Fatal(errCommand)
+				}
+				action.Validate(clientType, output)
+			})
+		}
+	}
+}

--- a/integration/client_crudl_test.go
+++ b/integration/client_crudl_test.go
@@ -17,7 +17,7 @@ type MobileClientJson struct {
 	Spec MobileClientSpec
 }
 
-func VMobileClientJson(name string, clientType string) func(output []byte, err error) (bool, []string) {
+func ValidMobileClientJson(name string, clientType string) func(output []byte, err error) (bool, []string) {
 	return func(output []byte, err error) (bool, []string) {
 		var parsed MobileClientJson
 		errJson := json.Unmarshal([]byte(output), &parsed)
@@ -44,22 +44,22 @@ func TestClientJson(t *testing.T) {
 
 	name := fmt.Sprintf("%s-mobile-crud-test-entity", *prefix)
 	m := ValidatedCmd(*executable, fmt.Sprintf("--namespace=%s", *namespace), "-o=json")
-	oc := ValidatedCmd("oc", fmt.Sprintf("--namespace=%s", *namespace), "-o=json")
+	o := ValidatedCmd("oc", fmt.Sprintf("--namespace=%s", *namespace), "-o=json")
 	for _, clientType := range clientTypes {
 		t.Run(clientType, func(t *testing.T) {
 			expectedId := strings.ToLower(fmt.Sprintf("%s-%s", name, clientType))
 
-			notExists := All(VIsErr, VRegex(fmt.Sprintf(".*\"%s\" not found.*", expectedId)))
-			exists := All(VNoErr, VMobileClientJson(name, clientType))
+			notExists := All(IsErr, ValidRegex(fmt.Sprintf(".*\"%s\" not found.*", expectedId)))
+			exists := All(NoErr, ValidMobileClientJson(name, clientType))
 
-			m.Add("get", "client", expectedId).Complying(notExists).Run(t)
-			oc.Add("get", "mobileclient", expectedId).Complying(notExists).Run(t)
-			m.Add("create", "client", name, clientType).Complying(exists).Run(t)
-			m.Add("get", "client", expectedId).Complying(exists).Run(t)
-			oc.Add("get", "mobileclient", expectedId).Complying(exists).Run(t)
-			m.Add("delete", "client", expectedId).Complying(VNoErr).Run(t)
-			m.Add("get", "client", expectedId).Complying(notExists).Run(t)
-			oc.Add("get", "mobileclient", expectedId).Complying(notExists).Run(t)
+			m.Args("get", "client", expectedId).Should(notExists).Run(t)
+			o.Args("get", "mobileclient", expectedId).Should(notExists).Run(t)
+			m.Args("create", "client", name, clientType).Should(exists).Run(t)
+			m.Args("get", "client", expectedId).Should(exists).Run(t)
+			o.Args("get", "mobileclient", expectedId).Should(exists).Run(t)
+			m.Args("delete", "client", expectedId).Should(NoErr).Run(t)
+			m.Args("get", "client", expectedId).Should(notExists).Run(t)
+			o.Args("get", "mobileclient", expectedId).Should(notExists).Run(t)
 		})
 	}
 }

--- a/integration/client_crudl_test.go
+++ b/integration/client_crudl_test.go
@@ -64,7 +64,7 @@ func TestClientJson(t *testing.T) {
 			m.Args("get", "client", expectedId).Should(notExists).Run().Test(t)
 			o.Args("get", "mobileclient", expectedId).Should(notExists).Run().Test(t)
 			m.Args("create", "client", name, clientType).Should(exists).Run().Test(t)
-			m.Args("get", "client", expectedId).Should(exists).Run(t).Run().Test(t)
+			m.Args("get", "client", expectedId).Should(exists).Run().Test(t)
 			o.Args("get", "mobileclient", expectedId).Should(exists).Run().Test(t)
 			m.Args("delete", "client", expectedId).Should(NoErr).Run().Test(t)
 			m.Args("get", "client", expectedId).Should(notExists).Run().Test(t)

--- a/integration/client_get_services_test.go
+++ b/integration/client_get_services_test.go
@@ -1,18 +1,10 @@
 package integration
 
 import (
-	"flag"
-	"fmt"
-	"os"
 	"os/exec"
-	"path"
 	"regexp"
 	"testing"
 )
-
-var namespace = flag.String("namespace", "myproject", "Openshift namespace (most often Project) to run our integration tests in")
-var executable = flag.String("executable", "mobile", "Executable under test")
-var update = flag.Bool("update", false, "update golden files")
 
 const testPath = "getServicesTestData/"
 
@@ -36,17 +28,12 @@ func TestGetServices(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := os.Getwd()
-			if err != nil {
-				t.Fatal(err)
-			}
-			cmd := exec.Command(path.Join(dir, *executable), test.args...)
+			cmd := exec.Command(*executable, test.args...)
 
 			output, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			if *update {
 				WriteSnapshot(t, testPath+test.fixture, output)
 			}
@@ -73,13 +60,4 @@ func cleanStringByRegex(input string, regexes []*regexp.Regexp) string {
 		input = regex.ReplaceAllString(input, "")
 	}
 	return input
-}
-
-func TestMain(m *testing.M) {
-	err := os.Chdir("..")
-	if err != nil {
-		fmt.Printf("could not change dir: %v", err)
-		os.Exit(1)
-	}
-	os.Exit(m.Run())
 }

--- a/integration/flags.go
+++ b/integration/flags.go
@@ -5,6 +5,6 @@ import (
 )
 
 var namespace = flag.String("namespace", "", "Openshift namespace (most often Project) to run our integration tests in")
-var prefix = flag.String("prefix", "", "Client name to be created")
+var prefix = flag.String("prefix", "test", "Client name to be created")
 var executable = flag.String("executable", "", "Executable under test")
 var update = flag.Bool("update", false, "update golden files")

--- a/integration/flags.go
+++ b/integration/flags.go
@@ -1,0 +1,10 @@
+package integration
+
+import (
+	"flag"
+)
+
+var namespace = flag.String("namespace", "", "Openshift namespace (most often Project) to run our integration tests in")
+var prefix = flag.String("prefix", "", "Client name to be created")
+var executable = flag.String("executable", "", "Executable under test")
+var update = flag.Bool("update", false, "update golden files")

--- a/integration/validatedCommandUtils.go
+++ b/integration/validatedCommandUtils.go
@@ -1,0 +1,77 @@
+package integration
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"testing"
+)
+
+type ValidationFunction = func(output []byte, err error) (bool, []string)
+
+func EmptyValidation(output []byte, err error) (bool, []string) {
+	return true, []string{}
+}
+
+func VNoErr(output []byte, err error) (bool, []string) {
+	return err == nil, []string{fmt.Sprintf("%s", err)}
+}
+
+func VIsErr(output []byte, err error) (bool, []string) {
+	return err != nil, []string{fmt.Sprintf("%s", err)}
+}
+
+func VRegex(pattern string) func(output []byte, err error) (bool, []string) {
+	return func(output []byte, err error) (bool, []string) {
+		matched, errMatch := regexp.MatchString(pattern, fmt.Sprintf("%s", output))
+		if errMatch != nil {
+			return false, []string{fmt.Sprintf("Error in regexp %s when trying to match %s", errMatch, pattern)}
+		}
+		if !matched {
+			return false, []string{fmt.Sprintf("Expected combined output matching %s", pattern)}
+		}
+		return true, []string{}
+	}
+}
+
+func All(vs ...ValidationFunction) ValidationFunction {
+	return func(output []byte, err error) (bool, []string) {
+		for _, v := range vs {
+			r, o := v(output, err)
+			if !r {
+				return r, o
+			}
+		}
+		return true, []string{}
+	}
+}
+
+type CmdDesc struct {
+	executable string
+	Arg        []string
+	Validator  ValidationFunction
+}
+
+func (c CmdDesc) Add(arg ...string) CmdDesc {
+	return CmdDesc{c.executable, append(c.Arg, arg...), c.Validator}
+}
+
+func (c CmdDesc) Complying(validator ValidationFunction) CmdDesc {
+	return CmdDesc{c.executable, c.Arg, All(c.Validator, validator)}
+}
+
+func (c CmdDesc) Run(t *testing.T) ([]byte, error) {
+	t.Log(c.Arg)
+	cmd := exec.Command(c.executable, c.Arg...)
+	output, err := cmd.CombinedOutput()
+	t.Log(fmt.Sprintf("%s\n", output))
+	v, errs := c.Validator(output, err)
+	if !v {
+		t.Fatal(errs)
+	}
+	return output, err
+}
+
+func ValidatedCmd(executable string, arg ...string) CmdDesc {
+	return CmdDesc{executable, arg, EmptyValidation}
+}

--- a/integration/validatedCommandUtils.go
+++ b/integration/validatedCommandUtils.go
@@ -15,7 +15,7 @@ type ValidationResult struct {
 }
 
 func (v ValidationResult) Test(t *testing.T) (output []byte, err error) {
-	t.Log(fmt.Sprintf("%s\n", output))
+	t.Log(fmt.Sprintf("%s\n", v.Output))
 	if !v.Success {
 		t.Fatal(v.Message)
 	}
@@ -84,21 +84,21 @@ func All(vs ...ValidationFunction) ValidationFunction {
 }
 
 type CmdDesc struct {
-	executable string
+	Executable string
 	Arg        []string
 	Validator  ValidationFunction
 }
 
 func (c CmdDesc) Args(arg ...string) CmdDesc {
-	return CmdDesc{c.executable, append(c.Arg, arg...), c.Validator}
+	return CmdDesc{c.Executable, append(c.Arg, arg...), c.Validator}
 }
 
 func (c CmdDesc) Should(validator ValidationFunction) CmdDesc {
-	return CmdDesc{c.executable, c.Arg, All(c.Validator, validator)}
+	return CmdDesc{c.Executable, c.Arg, All(c.Validator, validator)}
 }
 
 func (c CmdDesc) Run() ValidationResult {
-	cmd := exec.Command(c.executable, c.Arg...)
+	cmd := exec.Command(c.Executable, c.Arg...)
 	output, err := cmd.CombinedOutput()
 	return c.Validator(output, err)
 }

--- a/integration/validatedCommandUtils.go
+++ b/integration/validatedCommandUtils.go
@@ -13,15 +13,15 @@ func EmptyValidation(output []byte, err error) (bool, []string) {
 	return true, []string{}
 }
 
-func VNoErr(output []byte, err error) (bool, []string) {
+func NoErr(output []byte, err error) (bool, []string) {
 	return err == nil, []string{fmt.Sprintf("%s", err)}
 }
 
-func VIsErr(output []byte, err error) (bool, []string) {
+func IsErr(output []byte, err error) (bool, []string) {
 	return err != nil, []string{fmt.Sprintf("%s", err)}
 }
 
-func VRegex(pattern string) func(output []byte, err error) (bool, []string) {
+func ValidRegex(pattern string) func(output []byte, err error) (bool, []string) {
 	return func(output []byte, err error) (bool, []string) {
 		matched, errMatch := regexp.MatchString(pattern, fmt.Sprintf("%s", output))
 		if errMatch != nil {
@@ -52,11 +52,11 @@ type CmdDesc struct {
 	Validator  ValidationFunction
 }
 
-func (c CmdDesc) Add(arg ...string) CmdDesc {
+func (c CmdDesc) Args(arg ...string) CmdDesc {
 	return CmdDesc{c.executable, append(c.Arg, arg...), c.Validator}
 }
 
-func (c CmdDesc) Complying(validator ValidationFunction) CmdDesc {
+func (c CmdDesc) Should(validator ValidationFunction) CmdDesc {
 	return CmdDesc{c.executable, c.Arg, All(c.Validator, validator)}
 }
 


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

As described in https://issues.jboss.org/browse/AEROGEAR-1860, we need to have integration tests.

Changes proposed in this pull request
 - the https://raw.githubusercontent.com/aerogear/mobile-cli/master/artifacts/mobileclient_crd.yaml would be setup on our jenkins-wendy.ci, to allow to run this on PR.
 - the tests themselves are in go, using exec.Command to perform simple cli integration tests
 - for result verification we would be using -o json and json.Unmarshal
 - tests are using flags, to allow for parametrization, currently supporting -namespace and -name, it might be better if name was randomly generated
 - the tests should be reasonably stand-alone, allowing us to run them without setup

**To discuss**
- because we are testing eventually consistent system, we  probably need to allow for certain ammount of leeway when executing the tests, and include some ammount of timeout-based retries. We should agree on this.

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
- Might collide with @witmicko integration testing.

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes AEROGEAR-1860