### PR TITLE
do not panic if ~/.kube/config is missing

### DIFF
--- a/cmd/mobile/main.go
+++ b/cmd/mobile/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"k8s.io/client-go/kubernetes"
@@ -108,10 +109,13 @@ func main() {
 	}
 }
 
+// NewClientsOrDie creates a new set of clients for Kubernetes, Service Catalog and Mobile Services
+// if any of these clients fails to create then the process wil die.
 func NewClientsOrDie(configLoc string) (kubernetes.Interface, m.Interface, sc.Interface) {
 	config, err := clientcmd.BuildConfigFromFlags("", configLoc)
 	if err != nil {
-		panic(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
 	}
 
 	// create the K8client


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Currently the mobile CLI will panic if the `~/.kube/config` file is missing which can look like quite an intimidating error to new users.

Instead just output the error and exit with status 1.

Changes proposed in this pull request
 - Remove panic
 - Output error
 - exit status 1

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes AEROGEAR-1826