### PR TITLE
POC for running integration tests on wendy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,30 +7,57 @@ stage('Trust') {
     enforceTrustedApproval('aerogear')
 }
 
-node ("go") {
-  sh "mkdir -p src/github.com/aerogear/mobile-cli"
-  withEnv(["GOPATH=${env.WORKSPACE}/","PATH=${env.PATH}:${env.WORKSPACE}/bin"]) {
-    dir ("src/github.com/aerogear/mobile-cli") {
-      stage("Checkout") {
-        checkout scm
-      }
+@NonCPS
+String sanitizeObjectName(String s) {
+    s.replace('_', '-')
+        .replace('.', '-')
+        .toLowerCase()
+        .reverse()
+        .take(23)
+        .replaceAll("^-+", "")
+        .reverse()
+        .replaceAll("^-+", "")
+}
 
-      stage ("Setup") {
-        sh "glide install"
-      }
+// The jnlp container will be the one that the configured node will run on
+// you can define more containers and run them along-side
+def goSlaveContainer = containerTemplate(
+  name: 'jnlp', 
+  image: 'docker.io/fhwendy/jenkins-slave-go-centos7:201801081225',
+  args: '${computer.jnlpmac} ${computer.name}',
+  ttyEnabled: false) 
 
-      stage ("Build") {
-        sh "make build"
-      }
+podTemplate(label: 'mobile-cli-go', cloud: "openshift", containers: [goSlaveContainer]) {
+  node ("mobile-cli-go") {
+    sh "mkdir -p src/github.com/aerogear/mobile-cli"
+    withEnv(["GOPATH=${env.WORKSPACE}/","PATH=${env.PATH}:${env.WORKSPACE}/bin"]) {
+      dir ("src/github.com/aerogear/mobile-cli") {
+        stage("Checkout") {
+          checkout scm
+        }
 
-      stage ("Run") {
-        // workaround because of the https://issues.jboss.org/browse/FH-4471
-        sh "mkdir -p /home/jenkins/.kube"
-        sh "rm /home/jenkins/.kube/config || true"
-        sh "oc config view > /home/jenkins/.kube/config"
-        //end of workaround
+        stage ("Setup") {
+          sh "glide install"
+        }
 
-        sh "./mobile"
+        stage ("Build") {
+          sh "make build"
+        }
+
+        stage ("Run") {
+          // workaround because of the https://issues.jboss.org/browse/FH-4471
+          sh "mkdir -p /home/jenkins/.kube"
+          sh "rm /home/jenkins/.kube/config || true"
+          sh "oc config view > /home/jenkins/.kube/config"
+          //end of workaround
+
+          sh "./mobile"
+        }
+
+        stage ("Integration") {
+          sh "oc project pr-integration-aerogear-org-mobile-cli-repo"
+          sh "go test -v ./integration -args -prefix=test-${sanitizeObjectName(env.BRANCH_NAME)}-build-$BUILD_NUMBER -namespace=`oc project -q` -executable=`pwd`/mobile"
+        }
       }
     }
   }


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

This has been enabled with successful installation of ansible-service-broker on ci.feedhenry.org openshift.

Changes proposed in this pull request
 - added new test step that runs the integration tests
 - uses separate project, in our openshift called pr-integration-aerogear-org-mobile-cli-repo
 - will be creating entities with prefix test-$BRANCH_NAME-build-$BUILD_NUMBER

There might be challenges in the near future, if we plan to do integration testing of deployed services.
We might need to create/remove projects with every PR as is the case with apb-tests.

In addition, I am experimenting in defining the slave-container directly in the Jenkinsfile. Currently we have a shared definition for a type of slave, i.e. all go projects would share the same slave. This can lead to inconsistencies if two people need to change definition at the same time. I am hoping this would alleviate that :-)