### PR TITLE
change usage defaults

### DIFF
--- a/cmd/mobile/main.go
+++ b/cmd/mobile/main.go
@@ -100,6 +100,8 @@ func main() {
 		rootCmd.AddCommand(startCmd)
 	}
 
+	rootCmd.SilenceUsage = true
+
 	if err := rootCmd.Execute(); err != nil {
 		// as using pkg/errors lets allow the full stack to be seen if needed
 		if os.Getenv("MCP_DEBUG") == "true" {

--- a/pkg/cmd/clients.go
+++ b/pkg/cmd/clients.go
@@ -92,7 +92,7 @@ Run the "mobile get clients" command from this tool to get the client ID.`,
   oc plugin mobile get client <clientID>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return errors.New("missing argument <clientID>")
+				return cmd.Usage()
 			}
 			clientID := args[0]
 			ns, err := currentNamespace(cmd.Flags())
@@ -140,7 +140,7 @@ When used standalone, a namespace must be specified by providing the --namespace
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 3 {
-				return errors.New("expected a name a clientType and a appIdentifier")
+				return cmd.Usage()
 			}
 			name := args[0]
 			clientType := args[1]
@@ -217,7 +217,7 @@ Run the "mobile get clients" command from this tool to get the client ID.`,
 			var ns string
 
 			if len(args) != 1 {
-				return errors.New("expected a clientID argument to be passed " + cmd.Use)
+				return cmd.Usage()
 			}
 			clientID := args[0]
 

--- a/pkg/cmd/integration.go
+++ b/pkg/cmd/integration.go
@@ -113,7 +113,7 @@ oc plugin mobile create integration <consuming_service_instance_id> <providing_s
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
-				return errors.New("missing arguments: " + cmd.Use)
+				return cmd.Usage()
 			}
 			namespace, err := currentNamespace(cmd.Flags())
 			if err != nil {
@@ -185,7 +185,7 @@ oc plugin mobile delete integration <consuming_service_instance_id> <providing_s
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
-				return errors.New("missing arguments.")
+				return cmd.Usage()
 			}
 			namespace, err := currentNamespace(cmd.Flags())
 			if err != nil {

--- a/pkg/cmd/serviceConfig.go
+++ b/pkg/cmd/serviceConfig.go
@@ -123,8 +123,7 @@ func (scc *ServiceConfigCmd) GetServiceConfigCmd() *cobra.Command {
 		Short: "get a mobile aware service definition",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				//log.Println(")
-				return errors.Errorf("%v\n%v", "service name is required", cmd.Usage())
+				return cmd.Usage()
 			}
 			serviceName := args[0]
 			if serviceName == "" {

--- a/pkg/cmd/services.go
+++ b/pkg/cmd/services.go
@@ -212,7 +212,7 @@ Run the "mobile get services" command from this tool to see which services are a
   oc plugin mobile create serviceinstance <serviceName>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return errors.New("expected the name of a service to provision")
+				return cmd.Usage()
 			}
 			// find our serviceclass and plan
 			serviceName := args[0]
@@ -392,7 +392,7 @@ Run the "mobile get serviceinstances" command from this tool to see which servic
 			//delete service instance
 			//delete params secret
 			if len(args) != 1 {
-				return errors.New("expected a serviceInstanceID")
+				return cmd.Usage()
 			}
 			ns, err := currentNamespace(cmd.Flags())
 			if err != nil {
@@ -423,7 +423,7 @@ func (sc *ServicesCmd) ListServiceInstCmd() *cobra.Command {
   oc plugin mobile get serviceinstances <serviceName>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return errors.New("no service name passed")
+				return cmd.Usage()
 			}
 			serviceName := args[0]
 			ns, err := currentNamespace(cmd.Flags())

--- a/pkg/cmd/services_test.go
+++ b/pkg/cmd/services_test.go
@@ -41,11 +41,12 @@ func TestServicesCmd_DeleteServiceInstanceCmd(t *testing.T) {
 		K8Client         func() kubernetes.Interface
 		ExpectError      bool
 		ValidateErr      func(t *testing.T, err error)
+		ExpectUsage      bool
 		Flags            []string
 		Args             []string
 	}{
 		{
-			Name: "test if no service instance id passed that error returned",
+			Name: "test if no service instance id passed that usage is returned",
 			SvcCatalogClient: func() versioned.Interface {
 				fake := &scFake.Clientset{}
 				return fake
@@ -53,18 +54,10 @@ func TestServicesCmd_DeleteServiceInstanceCmd(t *testing.T) {
 			K8Client: func() kubernetes.Interface {
 				return &kFake.Clientset{}
 			},
-			ExpectError: true,
-			ValidateErr: func(t *testing.T, err error) {
-				expectedErr := "expected a serviceInstanceID"
-				if err == nil {
-					t.Fatalf("expected an error but did not get one")
-				}
-				if err.Error() != expectedErr {
-					t.Fatalf("expected error to be '%s' but got '%v'", expectedErr, err)
-				}
-			},
-			Flags: []string{"--namespace=test", "-o=json"},
-			Args:  []string{},
+			ExpectError: false,
+			ExpectUsage: true,
+			Flags:       []string{"--namespace=test", "-o=json"},
+			Args:        []string{},
 		},
 		{
 			Name: "test if error occurs getting service instance that an error is returned",
@@ -190,6 +183,9 @@ func TestServicesCmd_DeleteServiceInstanceCmd(t *testing.T) {
 			}
 			if tc.ValidateErr != nil {
 				tc.ValidateErr(t, err)
+			}
+			if tc.ExpectUsage && err != deleteServiceInstCmd.Usage() {
+				t.Fatalf("Expected error to be '%s' but got '%v'", deleteServiceInstCmd.Usage(), err)
 			}
 		})
 	}
@@ -462,6 +458,7 @@ func TestServicesCmd_ListServiceInstanceCmd(t *testing.T) {
 		SvcCatalogClient func() versioned.Interface
 		K8Client         func() kubernetes.Interface
 		ExpectError      bool
+		ExpectUsage      bool
 		ValidateErr      func(t *testing.T, err error)
 		ValidateOut      func(t *testing.T, output []byte)
 		Args             []string
@@ -504,7 +501,7 @@ func TestServicesCmd_ListServiceInstanceCmd(t *testing.T) {
 			Args:  []string{"keycloak"},
 		},
 		{
-			Name: "error is returned when no service name is passed",
+			Name: "Usage is returned when no service name is passed",
 			SvcCatalogClient: func() versioned.Interface {
 				fake := &scFake.Clientset{}
 				return fake
@@ -512,16 +509,8 @@ func TestServicesCmd_ListServiceInstanceCmd(t *testing.T) {
 			K8Client: func() kubernetes.Interface {
 				return &kFake.Clientset{}
 			},
-			ExpectError: true,
-			ValidateErr: func(t *testing.T, err error) {
-				expectedErr := "no service name passed"
-				if err == nil {
-					t.Fatalf("expected an error but did not get one")
-				}
-				if err.Error() != expectedErr {
-					t.Fatalf("expected error to be '%s' but got '%v'", expectedErr, err)
-				}
-			},
+			ExpectError: false,
+			ExpectUsage: true,
 		},
 		{
 			Name: "error is returned when no namespace is set",
@@ -570,6 +559,10 @@ func TestServicesCmd_ListServiceInstanceCmd(t *testing.T) {
 			if tc.ValidateErr != nil {
 				tc.ValidateErr(t, err)
 			}
+			if tc.ExpectUsage && err != listInstCmd.Usage() {
+				t.Fatalf("Expected error to be '%s' but got '%v'", listInstCmd.Usage(), err)
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Removing the usage from error output. When an error occurs we just need the relevant reason.

Changes proposed in this pull request
 - Removing the usage from error output
 - Return usage for specific instances of incorrect cli usage

Proposal change -> https://github.com/aerogear/proposals/pull/19