### PR TITLE
Fix hanging issue during watch when service provision fails

### DIFF
--- a/pkg/cmd/services.go
+++ b/pkg/cmd/services.go
@@ -362,6 +362,11 @@ Run the "mobile get services" command from this tool to see which services are a
 						if c.Type == "Ready" && c.Status == "True" {
 							w.Stop()
 						}
+
+						if c.Type == "Failed" {
+							w.Stop()
+							return errors.New("Failed to provision " + extServiceClass.ServiceName + ". " + c.Message)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
**Description**
The service provision watch hangs and never exits when service provision fails.

**Changes proposed**
- Add a check to see if the provision fails. If so, stop the watch and return the error.