### PR TITLE
add simple input validation for create parameters

### DIFF
--- a/pkg/cmd/services.go
+++ b/pkg/cmd/services.go
@@ -261,14 +261,32 @@ Run the "mobile get services" command from this tool to see which services are a
 			} else {
 				scanner := bufio.NewScanner(os.Stdin)
 				for k, v := range instParams.Properties {
-					questionFormat := "Set value for %s [default value: %s required: %v]"
+					validInput := false
+					val := ""
+					for validInput == false {
+						questionFormat := "Set value for %s [default value: %s required: %v]"
+						if v["default"] != nil {
+							fmt.Println(fmt.Sprintf(questionFormat, k, v["default"], requiredParam(*instParams, k)))
+						} else {
+							fmt.Println(fmt.Sprintf(questionFormat, k, "<no default value>", requiredParam(*instParams, k)))
+						}
+						scanner.Scan()
 
-					fmt.Println(fmt.Sprintf(questionFormat, k, v["default"], requiredParam(*instParams, k)))
-					scanner.Scan()
-					//
-					val := scanner.Text()
-					if val == "" {
-						val = v["default"].(string)
+						val = strings.TrimSpace(scanner.Text())
+
+						if len(val) > 0 {
+							validInput = true
+						}
+						if validInput == false && val == "" && v["default"] != nil {
+							val = v["default"].(string)
+							validInput = true
+						}
+						if validInput == false && val == "" && !requiredParam(*instParams, k) {
+							validInput = true
+						}
+						if validInput == false {
+							fmt.Println("Invalid option for required field.")
+						}
 					}
 					v["value"] = val
 					instParams.Properties[k] = v


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
The input validation on provision params had a flaw like this:
```
$ ./mobile create serviceinstance fh-sync-server --namespace=myproject
Set value for MONGODB_ADMIN_PASSWORD [default value: %!s(<nil>) required: false]

panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/aerogear/mobile-cli/pkg/cmd.(*ServicesCmd).CreateServiceInstanceCmd.func1(0xc4203fa900, 0xc4208f0280, 0x1, 0x2, 0x0, 0x0)
	/Users/pbrookes/repos/go-lang/src/github.com/aerogear/mobile-cli/pkg/cmd/services.go:271 +0x2252
github.com/aerogear/mobile-cli/vendor/github.com/spf13/cobra.(*Command).execute(0xc4203fa900, 0xc4208f0200, 0x2, 0x2, 0xc4203fa900, 0xc4208f0200)
	/Users/pbrookes/repos/go-lang/src/github.com/aerogear/mobile-cli/vendor/github.com/spf13/cobra/command.go:698 +0x47a
github.com/aerogear/mobile-cli/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc420502b40, 0xc4200c8b40, 0xc420502c80, 0xc420981f28)
	/Users/pbrookes/repos/go-lang/src/github.com/aerogear/mobile-cli/vendor/github.com/spf13/cobra/command.go:783 +0x30e
github.com/aerogear/mobile-cli/vendor/github.com/spf13/cobra.(*Command).Execute(0xc420502b40, 0xc420981f28, 0x1)
	/Users/pbrookes/repos/go-lang/src/github.com/aerogear/mobile-cli/vendor/github.com/spf13/cobra/command.go:736 +0x2b
main.main()
	/Users/pbrookes/repos/go-lang/src/github.com/aerogear/mobile-cli/cmd/mobile/main.go:105 +0xe4d
```
Changes proposed in this pull request
 - check default is valid
 - if required field and no value, re-ask for it
 - check value is nil before outputting

**Does this PR depend on another PR (Use this to track when PRs should be merged)**
depends-on <PR>

**Which issue this PR fixes (This will close that issue when PR gets merged)**
fixes <issue_number>