### PR TITLE
fix label selector

### DIFF
--- a/pkg/cmd/services.go
+++ b/pkg/cmd/services.go
@@ -361,7 +361,7 @@ Run the "mobile get services" command from this tool to see which services are a
 			if noWait {
 				return nil
 			}
-			w, err := sc.scClient.ServicecatalogV1beta1().ServiceInstances(ns).Watch(metav1.ListOptions{LabelSelector: "serviceName=" + validServiceName})
+			w, err := sc.scClient.ServicecatalogV1beta1().ServiceInstances(ns).Watch(metav1.ListOptions{LabelSelector: "serviceName=" + serviceName})
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/pkg/cmd/services.go
+++ b/pkg/cmd/services.go
@@ -328,10 +328,11 @@ Run the "mobile get services" command from this tool to see which services are a
 					},
 				},
 			}
+
 			if _, err := sc.scClient.ServicecatalogV1beta1().ServiceInstances(ns).Create(&si); err != nil {
 				return errors.WithStack(err)
 			}
-
+			fmt.Println("creating service")
 			pSecret := v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validServiceName + "-" + "params",
@@ -361,12 +362,15 @@ Run the "mobile get services" command from this tool to see which services are a
 			if noWait {
 				return nil
 			}
-			w, err := sc.scClient.ServicecatalogV1beta1().ServiceInstances(ns).Watch(metav1.ListOptions{LabelSelector: "serviceName=" + serviceName})
+			w, err := sc.scClient.ServicecatalogV1beta1().ServiceInstances(ns).Watch(metav1.ListOptions{})
 			if err != nil {
 				return errors.WithStack(err)
 			}
 			for u := range w.ResultChan() {
 				o := u.Object.(*v1beta1.ServiceInstance)
+				if o.Labels["serviceName"] != serviceName {
+					continue
+				}
 				switch u.Type {
 				case watch.Error:
 					w.Stop()


### PR DESCRIPTION
changes proposed in this pull request
 - change to use the correct name of the service

Issue here is that the apb now created the label, this means there is a timing issue. If we start watching before the label is present there will be nothing to watch. Instead we watch all serviceinstances and check the label as changes come in
