### PR TITLE
[WIP] E2E test for create integration command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ podTemplate(label: 'mobile-cli-go', cloud: "openshift", containers: [goSlaveCont
 
         stage ("Integration") {
           sh "oc project ${project}"
-          sh "go test -c ./integration"
+          sh "go test -timeout 30m -c ./integration"
           sh "./integration.test -test.v -prefix=test-${sanitizeObjectName(env.BRANCH_NAME)}-build-$BUILD_NUMBER -namespace=`oc project -q` -executable=`pwd`/mobile"
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,11 +54,12 @@ podTemplate(label: 'mobile-cli-go', cloud: "openshift", containers: [goSlaveCont
 
           sh "./mobile"
         }
+    
 
         stage ("Integration") {
           sh "oc project ${project}"
           sh "go test -timeout 30m -c ./integration"
-          sh "./integration.test -test.v -prefix=test-${sanitizeObjectName(env.BRANCH_NAME)}-build-$BUILD_NUMBER -namespace=`oc project -q` -executable=`pwd`/mobile"
+          sh "./integration.test -test.run Test[^I] -test.v -prefix=test-${sanitizeObjectName(env.BRANCH_NAME)}-build-$BUILD_NUMBER -namespace=`oc project -q` -executable=`pwd`/mobile"
         }
 
         stage ("Archive") {

--- a/Makefile
+++ b/Makefile
@@ -7,26 +7,35 @@ SHELL = /bin/bash
 
 LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
 
-
+.PHONY: setup
 setup:
 	@go get github.com/kisielk/errcheck
 	@go get github.com/goreleaser/goreleaser
 
+.PHONY: build
 build: setup check build_binary
 
+.PHONY: build_binary_linux
 build_binary_linux:
 	env GOOS=linux GOARCH=amd64 go build -o mobile ./cmd/mobile
 
+.PHONY: build_binary
 build_binary:
 	go build -o mobile ./cmd/mobile
 
+.PHONY: generate
 generate:
 	./scripts/generate.sh
 
+.PHONY: test-unit
 test-unit:
 	@echo Running tests:
 	go test -v -race -cover $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(PKG)/,$(TEST_DIRS))
+
+.PHONY: integration
+integration: build_binary
+	go test -v ./integration -args -namespace=`oc project -q` -executable=`pwd`/mobile
 
 .PHONY: errcheck
 errcheck:

--- a/integration/createIntegrationTestData/missing-args.golden
+++ b/integration/createIntegrationTestData/missing-args.golden
@@ -1,17 +1,1 @@
-Usage:
-  mobile create integration <consuming_service_instance_id> <providing_service_instance_id> [flags]
-
-Examples:
-  mobile create integration <consuming_service_instance_id> <providing_service_instance_id> --namespace=myproject
-  kubectl plugin mobile create integration <consuming_service_instance_id> <providing_service_instance_id>
-  oc plugin mobile create integration <consuming_service_instance_id> <providing_service_instance_id>
-
-Flags:
-      --auto-redeploy   --auto-redeploy=true will cause a backing deployment to be rolled out
-  -h, --help            help for integration
-      --no-wait         --no-wait will cause the command to exit immediately after a successful response instead of waiting until the binding is complete
-
-Global Flags:
-      --namespace string   --namespace=myproject
-  -o, --output string      -o=json -o=template (default "table")
-  -q, --quiet              -q all non essential output will be stopped
+Error: resource name may not be empty

--- a/integration/createIntegrationTestData/missing-args.golden
+++ b/integration/createIntegrationTestData/missing-args.golden
@@ -1,0 +1,17 @@
+Usage:
+  mobile create integration <consuming_service_instance_id> <providing_service_instance_id> [flags]
+
+Examples:
+  mobile create integration <consuming_service_instance_id> <providing_service_instance_id> --namespace=myproject
+  kubectl plugin mobile create integration <consuming_service_instance_id> <providing_service_instance_id>
+  oc plugin mobile create integration <consuming_service_instance_id> <providing_service_instance_id>
+
+Flags:
+      --auto-redeploy   --auto-redeploy=true will cause a backing deployment to be rolled out
+  -h, --help            help for integration
+      --no-wait         --no-wait will cause the command to exit immediately after a successful response instead of waiting until the binding is complete
+
+Global Flags:
+      --namespace string   --namespace=myproject
+  -o, --output string      -o=json -o=template (default "table")
+  -q, --quiet              -q all non essential output will be stopped

--- a/integration/create_integration_test.go
+++ b/integration/create_integration_test.go
@@ -1,0 +1,148 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+)
+
+const integrationTestPath = "createIntegrationTestData/"
+
+func TestCreateIntegration(t *testing.T) {
+	fhSyncServer := &ProvisionServiceParams{
+		Name:      "fh-sync-server",
+		Namespace: fmt.Sprintf("--namespace=%s", *namespace),
+		Params: []string{
+			"-p MONGODB_USER_NAME=fhsync",
+			"-p MONGODB_USER_PASSWORD=fhsyncpass",
+			"-p MONGODB_ADMIN_PASSWORD=pass",
+		},
+	}
+
+	keycloak := &ProvisionServiceParams{
+		Name:      "keycloak",
+		Namespace: fmt.Sprintf("--namespace=%s", *namespace),
+		Params: []string{
+			"-p ADMIN_NAME=admin",
+			"-p ADMIN_PASSWORD=pass",
+		},
+	}
+
+	// create fh-sync-server service instance
+	createInstance(t, fhSyncServer)
+	fhSyncID := getInstanceID(t, fhSyncServer)
+
+	// create keycloak service instance
+	createInstance(t, keycloak)
+	keycloakID := getInstanceID(t, keycloak)
+
+	tests := []struct {
+		name       string
+		fhSyncID   string
+		keycloakID string
+		fixture    string
+		validate   func(t *testing.T, sb *v1beta1.ServiceBinding)
+	}{
+		{
+			name:       "missing/incorrect arguments",
+			fhSyncID:   "",
+			keycloakID: "",
+			fixture:    "missing-args.golden",
+		},
+		{
+			name:       "create integration returns ready status",
+			fhSyncID:   fhSyncID,
+			keycloakID: keycloakID,
+			validate: func(t *testing.T, sb *v1beta1.ServiceBinding) {
+				expectedType := "Ready"
+				expectedStatus := "True"
+
+				if actualType := string(sb.Status.Conditions[0].Type); actualType != expectedType {
+					t.Fatalf("Expected condition type to be '%s' but got '%s'", expectedType, actualType)
+				}
+
+				if actualStatus := string(sb.Status.Conditions[0].Status); actualStatus != expectedStatus {
+					t.Fatalf("Expected condition status to be '%s' but got '%s'", expectedStatus, actualStatus)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// create service binding
+			args := []string{"create", "integration", test.fhSyncID, test.keycloakID, "--namespace=" + *namespace}
+			cmd := exec.Command(*executable, args...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("Failed to create binding: %v", err)
+			}
+			if *update {
+				WriteSnapshot(t, integrationTestPath+test.fixture, output)
+			}
+
+			if test.fixture != "" {
+				actual := string(output)
+				expected := LoadSnapshot(t, integrationTestPath+test.fixture)
+				if actual != expected {
+					t.Fatalf("actual = \n%s, expected = \n%s", actual, expected)
+				}
+			}
+
+			sb := getBinding(t)
+			if test.validate != nil {
+				test.validate(t, sb)
+			}
+		})
+	}
+}
+
+func createInstance(t *testing.T, si *ProvisionServiceParams) {
+	args := []string{"create", "serviceinstance", si.Name, si.Namespace}
+	args = append(args, si.Params...)
+	cmd := exec.Command(*executable, args...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to create service instance %s: %v", si.Name, err)
+	}
+
+	fmt.Println(string(output))
+}
+
+func getInstanceID(t *testing.T, si *ProvisionServiceParams) (id string) {
+	args := []string{"get", "serviceinstances", si.Name, si.Namespace, "-o=json"}
+	cmd := exec.Command(*executable, args...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to get instances for %s: %v", si.Name, err)
+	}
+
+	siList := &v1beta1.ServiceInstanceList{}
+	if err = json.Unmarshal(output, siList); err != nil {
+		t.Fatal("Unexpected error unmarshalling service instance list:", err)
+	}
+
+	return siList.Items[0].ObjectMeta.Name
+}
+
+func getBinding(t *testing.T) *v1beta1.ServiceBinding {
+	args := []string{"get", "integrations", "--namespace=" + *namespace, "-o=json"}
+	cmd := exec.Command(*executable, args...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal("Failed to get integrations:", err)
+	}
+
+	sbList := &v1beta1.ServiceBindingList{}
+	if err = json.Unmarshal(output, sbList); err != nil {
+		t.Fatal("Unexpected error unmarshalling service bindings list:", err)
+	}
+
+	return &sbList.Items[0]
+}

--- a/integration/service_integration_test.go
+++ b/integration/service_integration_test.go
@@ -34,12 +34,12 @@ func TestIntegration(t *testing.T) {
 	}
 
 	// create fh-sync-server service instance
-	createInstance(t, fhSyncServer)
-	fhSyncID := getInstanceID(t, fhSyncServer)
+	CreateInstance(t, fhSyncServer)
+	fhSyncID := GetInstanceID(t, fhSyncServer)
 
 	// create keycloak service instance
-	createInstance(t, keycloak)
-	keycloakID := getInstanceID(t, keycloak)
+	CreateInstance(t, keycloak)
+	keycloakID := GetInstanceID(t, keycloak)
 
 	tests := []struct {
 		name          string
@@ -59,7 +59,7 @@ func TestIntegration(t *testing.T) {
 			expectedError: nil,
 			args:          []string{"create", "integration", fhSyncID, keycloakID, "--namespace=" + *namespace},
 			validate: func(t *testing.T) {
-				sb, err := getBinding()
+				sb, err := GetBinding()
 				if err != nil {
 					t.Fatalf("error retrieving binding: %v\n", err)
 				}
@@ -88,7 +88,7 @@ func TestIntegration(t *testing.T) {
 			args:          []string{"delete", "integration", fhSyncID, keycloakID, "--namespace=" + *namespace},
 			validate: func(t *testing.T) {
 				expectedError := "Could not find servicebindings"
-				_, err := getBinding()
+				_, err := GetBinding()
 				if err == nil {
 					t.Fatalf("expected: '%v', got nil", expectedError)
 				} else if err.Error() != expectedError {
@@ -132,7 +132,7 @@ func TestIntegration(t *testing.T) {
 	}
 }
 
-func createInstance(t *testing.T, si *ProvisionServiceParams) {
+func CreateInstance(t *testing.T, si *ProvisionServiceParams) {
 	args := []string{"create", "serviceinstance", si.ServiceName, si.Namespace}
 	args = append(args, si.Params...)
 	cmd := exec.Command(*executable, args...)
@@ -145,7 +145,7 @@ func createInstance(t *testing.T, si *ProvisionServiceParams) {
 	fmt.Println(string(output))
 }
 
-func getInstanceID(t *testing.T, si *ProvisionServiceParams) (id string) {
+func GetInstanceID(t *testing.T, si *ProvisionServiceParams) (id string) {
 	args := []string{"get", "serviceinstances", si.ServiceName, si.Namespace, "-o=json"}
 	cmd := exec.Command(*executable, args...)
 
@@ -162,7 +162,7 @@ func getInstanceID(t *testing.T, si *ProvisionServiceParams) (id string) {
 	return siList.Items[0].ObjectMeta.Name
 }
 
-func getBinding() (*v1beta1.ServiceBinding, error) {
+func GetBinding() (*v1beta1.ServiceBinding, error) {
 	args := []string{"get", "integrations", "--namespace=" + *namespace, "-o=json"}
 	cmd := exec.Command(*executable, args...)
 

--- a/integration/service_integration_test.go
+++ b/integration/service_integration_test.go
@@ -78,7 +78,7 @@ func TestCreateIntegration(t *testing.T) {
 			cmd := exec.Command(*executable, args...)
 			output, err := cmd.CombinedOutput()
 			if err != nil {
-				t.Fatalf("Failed to create binding: %v", err)
+				t.Fatalf("Failed to create binding: %s", output)
 			}
 			if *update {
 				WriteSnapshot(t, integrationTestPath+test.fixture, output)
@@ -107,7 +107,7 @@ func createInstance(t *testing.T, si *ProvisionServiceParams) {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("Failed to create service instance %s: %v", si.ServiceName, err)
+		t.Fatalf("Failed to create service instance %s: %s", si.ServiceName, output)
 	}
 
 	fmt.Println(string(output))
@@ -119,7 +119,7 @@ func getInstanceID(t *testing.T, si *ProvisionServiceParams) (id string) {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("Failed to get instances for %s: %v", si.ServiceName, err)
+		t.Fatalf("Failed to get instances for %s: %s", si.ServiceName, output)
 	}
 
 	siList := &v1beta1.ServiceInstanceList{}
@@ -136,7 +136,7 @@ func getBinding(t *testing.T) *v1beta1.ServiceBinding {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatal("Failed to get integrations:", err)
+		t.Fatalf("Failed to get integrations: %s", output)
 	}
 
 	sbList := &v1beta1.ServiceBindingList{}

--- a/integration/service_integration_test.go
+++ b/integration/service_integration_test.go
@@ -13,8 +13,8 @@ const integrationTestPath = "createIntegrationTestData/"
 
 func TestCreateIntegration(t *testing.T) {
 	fhSyncServer := &ProvisionServiceParams{
-		Name:      "fh-sync-server",
-		Namespace: fmt.Sprintf("--namespace=%s", *namespace),
+		ServiceName: "fh-sync-server",
+		Namespace:   fmt.Sprintf("--namespace=%s", *namespace),
 		Params: []string{
 			"-p MONGODB_USER_NAME=fhsync",
 			"-p MONGODB_USER_PASSWORD=fhsyncpass",
@@ -23,8 +23,8 @@ func TestCreateIntegration(t *testing.T) {
 	}
 
 	keycloak := &ProvisionServiceParams{
-		Name:      "keycloak",
-		Namespace: fmt.Sprintf("--namespace=%s", *namespace),
+		ServiceName: "keycloak",
+		Namespace:   fmt.Sprintf("--namespace=%s", *namespace),
 		Params: []string{
 			"-p ADMIN_NAME=admin",
 			"-p ADMIN_PASSWORD=pass",
@@ -92,8 +92,8 @@ func TestCreateIntegration(t *testing.T) {
 				}
 			}
 
-			sb := getBinding(t)
 			if test.validate != nil {
+				sb := getBinding(t)
 				test.validate(t, sb)
 			}
 		})
@@ -101,25 +101,25 @@ func TestCreateIntegration(t *testing.T) {
 }
 
 func createInstance(t *testing.T, si *ProvisionServiceParams) {
-	args := []string{"create", "serviceinstance", si.Name, si.Namespace}
+	args := []string{"create", "serviceinstance", si.ServiceName, si.Namespace}
 	args = append(args, si.Params...)
 	cmd := exec.Command(*executable, args...)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("Failed to create service instance %s: %v", si.Name, err)
+		t.Fatalf("Failed to create service instance %s: %v", si.ServiceName, err)
 	}
 
 	fmt.Println(string(output))
 }
 
 func getInstanceID(t *testing.T, si *ProvisionServiceParams) (id string) {
-	args := []string{"get", "serviceinstances", si.Name, si.Namespace, "-o=json"}
+	args := []string{"get", "serviceinstances", si.ServiceName, si.Namespace, "-o=json"}
 	cmd := exec.Command(*executable, args...)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("Failed to get instances for %s: %v", si.Name, err)
+		t.Fatalf("Failed to get instances for %s: %v", si.ServiceName, err)
 	}
 
 	siList := &v1beta1.ServiceInstanceList{}

--- a/integration/types.go
+++ b/integration/types.go
@@ -16,7 +16,7 @@ type MobileClientJSON struct {
 }
 
 type ProvisionServiceParams struct {
-	Name      string
-	Namespace string
-	Params    []string
+	ServiceName string
+	Namespace   string
+	Params      []string
 }

--- a/integration/types.go
+++ b/integration/types.go
@@ -14,3 +14,9 @@ type MobileClientSpec struct {
 type MobileClientJSON struct {
 	Spec MobileClientSpec
 }
+
+type ProvisionServiceParams struct {
+	Name      string
+	Namespace string
+	Params    []string
+}

--- a/pkg/cmd/services.go
+++ b/pkg/cmd/services.go
@@ -147,6 +147,10 @@ func findServiceClassByName(scClient versioned.Interface, name string) (*v1beta1
 
 	for _, item := range mobileServices.Items {
 		var extData ExternalServiceMetaData
+		// skip services with no external metadata
+		if item.Spec.ExternalMetadata == nil {
+			continue
+		}
 		rawData := item.Spec.ExternalMetadata.Raw
 		if err := json.Unmarshal(rawData, &extData); err != nil {
 			return nil, err


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Integration test for the `create integration` command
The test is focused on the binding between `fh-sync-server` and `keycloak`.

**Changes proposed in this pull request**
- Add integration test and golden files for the `create integration` command

**This PR fixes the following issue**
[AEROGEAR-1925](https://issues.jboss.org/browse/AEROGEAR-1925)