### PR TITLE
Using -short flag instead of the regex skip

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ podTemplate(label: 'mobile-cli-go', cloud: "openshift", containers: [goSlaveCont
         stage ("Integration") {
           sh "oc project ${project}"
           sh "go test -timeout 30m -c ./integration"
-          sh "./integration.test -test.run Test[^I] -test.v -prefix=test-${sanitizeObjectName(env.BRANCH_NAME)}-build-$BUILD_NUMBER -namespace=`oc project -q` -executable=`pwd`/mobile"
+          sh "./integration.test -test.short -test.v -prefix=test-${sanitizeObjectName(env.BRANCH_NAME)}-build-$BUILD_NUMBER -namespace=`oc project -q` -executable=`pwd`/mobile"
         }
 
         stage ("Archive") {
@@ -68,6 +68,10 @@ podTemplate(label: 'mobile-cli-go', cloud: "openshift", containers: [goSlaveCont
           sh "cp integration.test out/"
           sh "cp -R integration out/integration"
           archiveArtifacts artifacts: 'out/**'
+        }
+
+        stage ("Clear Project") {
+            "sh oc delete project ${project}"
         }
       }
     }

--- a/integration/service_integration_test.go
+++ b/integration/service_integration_test.go
@@ -14,6 +14,10 @@ import (
 const integrationTestPath = "createIntegrationTestData/"
 
 func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration testing in short mode")
+	}
+
 	fhSyncServer := &ProvisionServiceParams{
 		ServiceName: "fh-sync-server",
 		Namespace:   fmt.Sprintf("--namespace=%s", *namespace),


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

Changes proposed in this pull request
 - We need a way to separate tests that are too heavy to run on every PR
 - Previously we just filtered them out with RegEx, but that is a brittle solution
 - flag -test.short seems to be a good fit for this
