### PR TITLE
Removed the deletion test until the service deletion works reliably

### DIFF
--- a/integration/client_delete_serviceInstance_test.go
+++ b/integration/client_delete_serviceInstance_test.go
@@ -16,6 +16,9 @@ import (
 const deleteServicetestPath = "deleteServiceInstanceTestData/"
 
 func TestDeleteServiceInstance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration testing in short mode")
+	}
 
 	fhSyncServer := &ProvisionServiceParams{
 		ServiceName: "fh-sync-server",


### PR DESCRIPTION
**Describe what this PR does and why we need it**:

Changes proposed in this pull request
 - We are seeing too many un-erasable project on our CI openshift.
 - So I am removing the test that is generating these projects until we fix the underlying culprit
 