### PR TITLE
add icon as annotation

### DIFF
--- a/pkg/cmd/clients.go
+++ b/pkg/cmd/clients.go
@@ -157,19 +157,20 @@ When used standalone, a namespace must be specified by providing the --namespace
 					APIVersion: "mobile.k8s.io/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{},
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
 				},
 				Spec: v1alpha1.MobileClientSpec{Name: name, ApiKey: appKey, ClientType: clientType, AppIdentifier: appIdentifier},
 			}
 			switch app.Spec.ClientType {
 			case "android":
-				app.Labels["icon"] = "fa-android"
+				app.Annotations["icon"] = "fa fa-android"
 				break
 			case "iOS":
-				app.Labels["icon"] = "fa-apple"
+				app.Annotations["icon"] = "fa fa-apple"
 				break
 			case "cordova":
-				app.Labels["icon"] = "icon-cordova"
+				app.Annotations["icon"] = "font-icon icon-cordova"
 				break
 			}
 			app.Name = name + "-" + strings.ToLower(app.Spec.ClientType)

--- a/pkg/cmd/clients_test.go
+++ b/pkg/cmd/clients_test.go
@@ -334,11 +334,11 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 				if c.Spec.ApiKey == "" {
 					t.Fatal("expected an apiKey to be generated but it was empty")
 				}
-				icon, ok := c.Labels["icon"]
+				icon, ok := c.Annotations["icon"]
 				if !ok {
 					t.Fatal("expected an icon to be set but there was none")
 				}
-				if icon != "icon-cordova" {
+				if icon != "font-icon icon-cordova" {
 					t.Fatal("expected the icon to be icon-cordova but got ", icon)
 				}
 			},
@@ -371,11 +371,11 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 				if c.Spec.ApiKey == "" {
 					t.Fatal("expected an apiKey to be generated but it was empty")
 				}
-				icon, ok := c.Labels["icon"]
+				icon, ok := c.Annotations["icon"]
 				if !ok {
 					t.Fatal("expected an icon to be set but there was none")
 				}
-				if icon != "fa-android" {
+				if icon != "fa fa-android" {
 					t.Fatal("expected the icon to be fa-android but got ", icon)
 				}
 			},
@@ -408,11 +408,11 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 				if c.Spec.ApiKey == "" {
 					t.Fatal("expected an apiKey to be generated but it was empty")
 				}
-				icon, ok := c.Labels["icon"]
+				icon, ok := c.Annotations["icon"]
 				if !ok {
 					t.Fatal("expected an icon to be set but there was none")
 				}
-				if icon != "fa-apple" {
+				if icon != "fa fa-apple" {
 					t.Fatal("expected the icon to be fa-apple but got ", icon)
 				}
 			},


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
The icons should be part of the annotations as this is the standard way to store information like this. Labels are generally used for grouping, tagging and filtering
Changes proposed in this pull request
 - switch to using annotations
