### PR TITLE
Clean code and redundant import aliases

### DIFF
--- a/pkg/apis/mobile/register.go
+++ b/pkg/apis/mobile/register.go
@@ -28,8 +28,8 @@ var (
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
-		&MobileClient{},
-		&MobileClientList{},
+		&Client{},
+		&ClientList{},
 	)
 	return nil
 }

--- a/pkg/apis/mobile/types.go
+++ b/pkg/apis/mobile/types.go
@@ -2,15 +2,15 @@ package mobile
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// MobileClientList is a list of MobileClient objects.
-type MobileClientList struct {
+// ClientList is a list of Client objects.
+type ClientList struct {
 	metav1.TypeMeta
 	metav1.ListMeta
 
-	Items []MobileClient
+	Items []Client
 }
 
-type MobileClientSpec struct {
+type ClientSpec struct {
 	Name          string
 	ApiKey        string
 	ClientType    string
@@ -19,9 +19,9 @@ type MobileClientSpec struct {
 
 // +genclient
 
-type MobileClient struct {
+type Client struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
 
-	Spec MobileClientSpec
+	Spec ClientSpec
 }

--- a/pkg/apis/mobile/v1alpha1/register.go
+++ b/pkg/apis/mobile/v1alpha1/register.go
@@ -36,6 +36,11 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	return nil
 }
 
+// Kind takes an unqualified kind and returns back a Group qualified GroupKind
+func Kind(kind string) schema.GroupKind {
+	return SchemeGroupVersion.WithKind(kind).GroupKind()
+}
+
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()

--- a/pkg/apis/servicecatalog/register.go
+++ b/pkg/apis/servicecatalog/register.go
@@ -40,8 +40,8 @@ func Resource(resource string) schema.GroupResource {
 var (
 	// SchemeBuilder needs to be exported as `SchemeBuilder` so
 	// the code-generation can find it.
-	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
-	localSchemeBuilder = &SchemeBuilder
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+
 	// AddToScheme is exposed for API installation
 	AddToScheme = SchemeBuilder.AddToScheme
 )

--- a/pkg/apis/servicecatalog/types.go
+++ b/pkg/apis/servicecatalog/types.go
@@ -823,7 +823,7 @@ const (
 
 // These are internal finalizer values to service catalog, must be qualified name.
 const (
-	FinalizerServiceCatalog string = "kubernetes-incubator/service-catalog"
+	FinalizerServiceCatalog = "kubernetes-incubator/service-catalog"
 )
 
 // ServiceBindingPropertiesState is the state of a

--- a/pkg/apis/servicecatalog/v1beta1/register.go
+++ b/pkg/apis/servicecatalog/v1beta1/register.go
@@ -42,8 +42,8 @@ func Resource(resource string) schema.GroupResource {
 var (
 	// SchemeBuilder needs to be exported as `SchemeBuilder` so
 	// the code-generation can find it.
-	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
-	localSchemeBuilder = &SchemeBuilder
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+
 	// AddToScheme is exposed for API installation
 	AddToScheme = SchemeBuilder.AddToScheme
 )

--- a/pkg/apis/servicecatalog/v1beta1/types.go
+++ b/pkg/apis/servicecatalog/v1beta1/types.go
@@ -867,7 +867,7 @@ const (
 
 // These are external finalizer values to service catalog, must be qualified name.
 const (
-	FinalizerServiceCatalog string = "kubernetes-incubator/service-catalog"
+	FinalizerServiceCatalog = "kubernetes-incubator/service-catalog"
 )
 
 // ServiceBindingPropertiesState is the state of a

--- a/pkg/client/mobile/clientset/internalversion/clientset.go
+++ b/pkg/client/mobile/clientset/internalversion/clientset.go
@@ -18,10 +18,10 @@ package internalversion
 
 import (
 	mobileinternalversion "github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion"
-	glog "github.com/golang/glog"
-	discovery "k8s.io/client-go/discovery"
-	rest "k8s.io/client-go/rest"
-	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"github.com/golang/glog"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 )
 
 type Interface interface {

--- a/pkg/client/mobile/clientset/internalversion/fake/clientset_generated.go
+++ b/pkg/client/mobile/clientset/internalversion/fake/clientset_generated.go
@@ -27,11 +27,11 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientSet returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+func NewSimpleClientSet(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -60,7 +60,7 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 var _ clientset.Interface = &Clientset{}
 
-// Mobile retrieves the MobileClient
+// Mobile retrieves the Client
 func (c *Clientset) Mobile() mobileinternalversion.MobileInterface {
-	return &fakemobileinternalversion.FakeMobile{Fake: &c.Fake}
+	return &fakemobileinternalversion.Mobile{Fake: &c.Fake}
 }

--- a/pkg/client/mobile/clientset/internalversion/fake/register.go
+++ b/pkg/client/mobile/clientset/internalversion/fake/register.go
@@ -18,15 +18,14 @@ package fake
 
 import (
 	mobileinternalversion "github.com/aerogear/mobile-cli/pkg/apis/mobile"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-var parameterCodec = runtime.NewParameterCodec(scheme)
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})

--- a/pkg/client/mobile/clientset/internalversion/scheme/register.go
+++ b/pkg/client/mobile/clientset/internalversion/scheme/register.go
@@ -18,13 +18,13 @@ package scheme
 
 import (
 	mobile "github.com/aerogear/mobile-cli/pkg/apis/mobile/install"
-	announced "k8s.io/apimachinery/pkg/apimachinery/announced"
-	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	os "os"
+	"k8s.io/apimachinery/pkg/apimachinery/announced"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"os"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion/fake/fake_mobile_client.go
+++ b/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion/fake/fake_mobile_client.go
@@ -17,22 +17,22 @@ limitations under the License.
 package fake
 
 import (
-	internalversion "github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion"
-	rest "k8s.io/client-go/rest"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/testing"
 )
 
-type FakeMobile struct {
+type Mobile struct {
 	*testing.Fake
 }
 
-func (c *FakeMobile) MobileClients(namespace string) internalversion.MobileClientInterface {
-	return &FakeMobileClients{c, namespace}
+func (c *Mobile) MobileClients(namespace string) internalversion.MobileClientInterface {
+	return &MobileClients{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeMobile) RESTClient() rest.Interface {
+func (c *Mobile) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion/fake/fake_mobileclient.go
+++ b/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion/fake/fake_mobileclient.go
@@ -17,40 +17,40 @@ limitations under the License.
 package fake
 
 import (
-	mobile "github.com/aerogear/mobile-cli/pkg/apis/mobile"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/mobile"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeMobileClients implements MobileClientInterface
-type FakeMobileClients struct {
-	Fake *FakeMobile
+// MobileClients implements MobileClientInterface
+type MobileClients struct {
+	Fake *Mobile
 	ns   string
 }
 
 var mobileclientsResource = schema.GroupVersionResource{Group: "mobile.k8s.io", Version: "", Resource: "mobileclients"}
 
-var mobileclientsKind = schema.GroupVersionKind{Group: "mobile.k8s.io", Version: "", Kind: "MobileClient"}
+var mobileclientsKind = schema.GroupVersionKind{Group: "mobile.k8s.io", Version: "", Kind: "Client"}
 
 // Get takes name of the mobileClient, and returns the corresponding mobileClient object, and an error if there is any.
-func (c *FakeMobileClients) Get(name string, options v1.GetOptions) (result *mobile.MobileClient, err error) {
+func (c *MobileClients) Get(name string, options v1.GetOptions) (result *mobile.Client, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(mobileclientsResource, c.ns, name), &mobile.MobileClient{})
+		Invokes(testing.NewGetAction(mobileclientsResource, c.ns, name), &mobile.Client{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*mobile.MobileClient), err
+	return obj.(*mobile.Client), err
 }
 
 // List takes label and field selectors, and returns the list of MobileClients that match those selectors.
-func (c *FakeMobileClients) List(opts v1.ListOptions) (result *mobile.MobileClientList, err error) {
+func (c *MobileClients) List(opts v1.ListOptions) (result *mobile.ClientList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(mobileclientsResource, mobileclientsKind, c.ns, opts), &mobile.MobileClientList{})
+		Invokes(testing.NewListAction(mobileclientsResource, mobileclientsKind, c.ns, opts), &mobile.ClientList{})
 
 	if obj == nil {
 		return nil, err
@@ -60,8 +60,8 @@ func (c *FakeMobileClients) List(opts v1.ListOptions) (result *mobile.MobileClie
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &mobile.MobileClientList{}
-	for _, item := range obj.(*mobile.MobileClientList).Items {
+	list := &mobile.ClientList{}
+	for _, item := range obj.(*mobile.ClientList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -70,57 +70,57 @@ func (c *FakeMobileClients) List(opts v1.ListOptions) (result *mobile.MobileClie
 }
 
 // Watch returns a watch.Interface that watches the requested mobileClients.
-func (c *FakeMobileClients) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *MobileClients) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(mobileclientsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a mobileClient and creates it.  Returns the server's representation of the mobileClient, and an error, if there is any.
-func (c *FakeMobileClients) Create(mobileClient *mobile.MobileClient) (result *mobile.MobileClient, err error) {
+func (c *MobileClients) Create(mobileClient *mobile.Client) (result *mobile.Client, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(mobileclientsResource, c.ns, mobileClient), &mobile.MobileClient{})
+		Invokes(testing.NewCreateAction(mobileclientsResource, c.ns, mobileClient), &mobile.Client{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*mobile.MobileClient), err
+	return obj.(*mobile.Client), err
 }
 
 // Update takes the representation of a mobileClient and updates it. Returns the server's representation of the mobileClient, and an error, if there is any.
-func (c *FakeMobileClients) Update(mobileClient *mobile.MobileClient) (result *mobile.MobileClient, err error) {
+func (c *MobileClients) Update(mobileClient *mobile.Client) (result *mobile.Client, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(mobileclientsResource, c.ns, mobileClient), &mobile.MobileClient{})
+		Invokes(testing.NewUpdateAction(mobileclientsResource, c.ns, mobileClient), &mobile.Client{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*mobile.MobileClient), err
+	return obj.(*mobile.Client), err
 }
 
 // Delete takes name of the mobileClient and deletes it. Returns an error if one occurs.
-func (c *FakeMobileClients) Delete(name string, options *v1.DeleteOptions) error {
+func (c *MobileClients) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(mobileclientsResource, c.ns, name), &mobile.MobileClient{})
+		Invokes(testing.NewDeleteAction(mobileclientsResource, c.ns, name), &mobile.Client{})
 
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeMobileClients) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *MobileClients) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(mobileclientsResource, c.ns, listOptions)
 
-	_, err := c.Fake.Invokes(action, &mobile.MobileClientList{})
+	_, err := c.Fake.Invokes(action, &mobile.ClientList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched mobileClient.
-func (c *FakeMobileClients) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *mobile.MobileClient, err error) {
+func (c *MobileClients) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *mobile.Client, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(mobileclientsResource, c.ns, name, data, subresources...), &mobile.MobileClient{})
+		Invokes(testing.NewPatchSubresourceAction(mobileclientsResource, c.ns, name, data, subresources...), &mobile.Client{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*mobile.MobileClient), err
+	return obj.(*mobile.Client), err
 }

--- a/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion/mobile_client.go
+++ b/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion/mobile_client.go
@@ -18,7 +18,7 @@ package internalversion
 
 import (
 	"github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/internalversion/scheme"
-	rest "k8s.io/client-go/rest"
+	"k8s.io/client-go/rest"
 )
 
 type MobileInterface interface {
@@ -26,7 +26,7 @@ type MobileInterface interface {
 	MobileClientsGetter
 }
 
-// MobileClient is used to interact with features provided by the mobile.k8s.io group.
+// Client is used to interact with features provided by the mobile.k8s.io group.
 type MobileClient struct {
 	restClient rest.Interface
 }
@@ -35,7 +35,7 @@ func (c *MobileClient) MobileClients(namespace string) MobileClientInterface {
 	return newMobileClients(c, namespace)
 }
 
-// NewForConfig creates a new MobileClient for the given config.
+// NewForConfig creates a new Client for the given config.
 func NewForConfig(c *rest.Config) (*MobileClient, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
@@ -48,7 +48,7 @@ func NewForConfig(c *rest.Config) (*MobileClient, error) {
 	return &MobileClient{client}, nil
 }
 
-// NewForConfigOrDie creates a new MobileClient for the given config and
+// NewForConfigOrDie creates a new Client for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *MobileClient {
 	client, err := NewForConfig(c)
@@ -58,7 +58,7 @@ func NewForConfigOrDie(c *rest.Config) *MobileClient {
 	return client
 }
 
-// New creates a new MobileClient for the given RESTClient.
+// New creates a new Client for the given RESTClient.
 func New(c rest.Interface) *MobileClient {
 	return &MobileClient{c}
 }

--- a/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion/mobileclient.go
+++ b/pkg/client/mobile/clientset/internalversion/typed/mobile/internalversion/mobileclient.go
@@ -17,12 +17,12 @@ limitations under the License.
 package internalversion
 
 import (
-	mobile "github.com/aerogear/mobile-cli/pkg/apis/mobile"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/internalversion/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/mobile"
+	"github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/internalversion/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // MobileClientsGetter has a method to return a MobileClientInterface.
@@ -31,16 +31,16 @@ type MobileClientsGetter interface {
 	MobileClients(namespace string) MobileClientInterface
 }
 
-// MobileClientInterface has methods to work with MobileClient resources.
+// MobileClientInterface has methods to work with Client resources.
 type MobileClientInterface interface {
-	Create(*mobile.MobileClient) (*mobile.MobileClient, error)
-	Update(*mobile.MobileClient) (*mobile.MobileClient, error)
+	Create(*mobile.Client) (*mobile.Client, error)
+	Update(*mobile.Client) (*mobile.Client, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
-	Get(name string, options v1.GetOptions) (*mobile.MobileClient, error)
-	List(opts v1.ListOptions) (*mobile.MobileClientList, error)
+	Get(name string, options v1.GetOptions) (*mobile.Client, error)
+	List(opts v1.ListOptions) (*mobile.ClientList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *mobile.MobileClient, err error)
+	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *mobile.Client, err error)
 	MobileClientExpansion
 }
 
@@ -59,8 +59,8 @@ func newMobileClients(c *MobileClient, namespace string) *mobileClients {
 }
 
 // Get takes name of the mobileClient, and returns the corresponding mobileClient object, and an error if there is any.
-func (c *mobileClients) Get(name string, options v1.GetOptions) (result *mobile.MobileClient, err error) {
-	result = &mobile.MobileClient{}
+func (c *mobileClients) Get(name string, options v1.GetOptions) (result *mobile.Client, err error) {
+	result = &mobile.Client{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("mobileclients").
@@ -72,8 +72,8 @@ func (c *mobileClients) Get(name string, options v1.GetOptions) (result *mobile.
 }
 
 // List takes label and field selectors, and returns the list of MobileClients that match those selectors.
-func (c *mobileClients) List(opts v1.ListOptions) (result *mobile.MobileClientList, err error) {
-	result = &mobile.MobileClientList{}
+func (c *mobileClients) List(opts v1.ListOptions) (result *mobile.ClientList, err error) {
+	result = &mobile.ClientList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("mobileclients").
@@ -94,8 +94,8 @@ func (c *mobileClients) Watch(opts v1.ListOptions) (watch.Interface, error) {
 }
 
 // Create takes the representation of a mobileClient and creates it.  Returns the server's representation of the mobileClient, and an error, if there is any.
-func (c *mobileClients) Create(mobileClient *mobile.MobileClient) (result *mobile.MobileClient, err error) {
-	result = &mobile.MobileClient{}
+func (c *mobileClients) Create(mobileClient *mobile.Client) (result *mobile.Client, err error) {
+	result = &mobile.Client{}
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("mobileclients").
@@ -106,8 +106,8 @@ func (c *mobileClients) Create(mobileClient *mobile.MobileClient) (result *mobil
 }
 
 // Update takes the representation of a mobileClient and updates it. Returns the server's representation of the mobileClient, and an error, if there is any.
-func (c *mobileClients) Update(mobileClient *mobile.MobileClient) (result *mobile.MobileClient, err error) {
-	result = &mobile.MobileClient{}
+func (c *mobileClients) Update(mobileClient *mobile.Client) (result *mobile.Client, err error) {
+	result = &mobile.Client{}
 	err = c.client.Put().
 		Namespace(c.ns).
 		Resource("mobileclients").
@@ -141,8 +141,8 @@ func (c *mobileClients) DeleteCollection(options *v1.DeleteOptions, listOptions 
 }
 
 // Patch applies the patch and returns the patched mobileClient.
-func (c *mobileClients) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *mobile.MobileClient, err error) {
-	result = &mobile.MobileClient{}
+func (c *mobileClients) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *mobile.Client, err error) {
+	result = &mobile.Client{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("mobileclients").

--- a/pkg/client/mobile/clientset/versioned/clientset.go
+++ b/pkg/client/mobile/clientset/versioned/clientset.go
@@ -18,10 +18,10 @@ package versioned
 
 import (
 	mobilev1alpha1 "github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1"
-	glog "github.com/golang/glog"
-	discovery "k8s.io/client-go/discovery"
-	rest "k8s.io/client-go/rest"
-	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"github.com/golang/glog"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 )
 
 type Interface interface {

--- a/pkg/client/mobile/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/mobile/clientset/versioned/fake/clientset_generated.go
@@ -27,11 +27,11 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientSet returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+func NewSimpleClientSet(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -62,10 +62,10 @@ var _ clientset.Interface = &Clientset{}
 
 // MobileV1alpha1 retrieves the MobileV1alpha1Client
 func (c *Clientset) MobileV1alpha1() mobilev1alpha1.MobileV1alpha1Interface {
-	return &fakemobilev1alpha1.FakeMobileV1alpha1{Fake: &c.Fake}
+	return &fakemobilev1alpha1.MobileV1alpha1{Fake: &c.Fake}
 }
 
 // Mobile retrieves the MobileV1alpha1Client
 func (c *Clientset) Mobile() mobilev1alpha1.MobileV1alpha1Interface {
-	return &fakemobilev1alpha1.FakeMobileV1alpha1{Fake: &c.Fake}
+	return &fakemobilev1alpha1.MobileV1alpha1{Fake: &c.Fake}
 }

--- a/pkg/client/mobile/clientset/versioned/fake/register.go
+++ b/pkg/client/mobile/clientset/versioned/fake/register.go
@@ -18,15 +18,14 @@ package fake
 
 import (
 	mobilev1alpha1 "github.com/aerogear/mobile-cli/pkg/apis/mobile/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-var parameterCodec = runtime.NewParameterCodec(scheme)
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})

--- a/pkg/client/mobile/clientset/versioned/scheme/register.go
+++ b/pkg/client/mobile/clientset/versioned/scheme/register.go
@@ -18,10 +18,10 @@ package scheme
 
 import (
 	mobilev1alpha1 "github.com/aerogear/mobile-cli/pkg/apis/mobile/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1/fake/fake_mobile_client.go
+++ b/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1/fake/fake_mobile_client.go
@@ -17,22 +17,22 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1"
-	rest "k8s.io/client-go/rest"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/testing"
 )
 
-type FakeMobileV1alpha1 struct {
+type MobileV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeMobileV1alpha1) MobileClients(namespace string) v1alpha1.MobileClientInterface {
-	return &FakeMobileClients{c, namespace}
+func (c *MobileV1alpha1) MobileClients(namespace string) v1alpha1.MobileClientInterface {
+	return &MobileClients{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeMobileV1alpha1) RESTClient() rest.Interface {
+func (c *MobileV1alpha1) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1/fake/fake_mobileclient.go
+++ b/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1/fake/fake_mobileclient.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/aerogear/mobile-cli/pkg/apis/mobile/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/mobile/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeMobileClients implements MobileClientInterface
-type FakeMobileClients struct {
-	Fake *FakeMobileV1alpha1
+// MobileClients implements MobileClientInterface
+type MobileClients struct {
+	Fake *MobileV1alpha1
 	ns   string
 }
 
@@ -37,7 +37,7 @@ var mobileclientsResource = schema.GroupVersionResource{Group: "mobile.k8s.io", 
 var mobileclientsKind = schema.GroupVersionKind{Group: "mobile.k8s.io", Version: "v1alpha1", Kind: "MobileClient"}
 
 // Get takes name of the mobileClient, and returns the corresponding mobileClient object, and an error if there is any.
-func (c *FakeMobileClients) Get(name string, options v1.GetOptions) (result *v1alpha1.MobileClient, err error) {
+func (c *MobileClients) Get(name string, options v1.GetOptions) (result *v1alpha1.MobileClient, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(mobileclientsResource, c.ns, name), &v1alpha1.MobileClient{})
 
@@ -48,7 +48,7 @@ func (c *FakeMobileClients) Get(name string, options v1.GetOptions) (result *v1a
 }
 
 // List takes label and field selectors, and returns the list of MobileClients that match those selectors.
-func (c *FakeMobileClients) List(opts v1.ListOptions) (result *v1alpha1.MobileClientList, err error) {
+func (c *MobileClients) List(opts v1.ListOptions) (result *v1alpha1.MobileClientList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(mobileclientsResource, mobileclientsKind, c.ns, opts), &v1alpha1.MobileClientList{})
 
@@ -70,14 +70,14 @@ func (c *FakeMobileClients) List(opts v1.ListOptions) (result *v1alpha1.MobileCl
 }
 
 // Watch returns a watch.Interface that watches the requested mobileClients.
-func (c *FakeMobileClients) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *MobileClients) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(mobileclientsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a mobileClient and creates it.  Returns the server's representation of the mobileClient, and an error, if there is any.
-func (c *FakeMobileClients) Create(mobileClient *v1alpha1.MobileClient) (result *v1alpha1.MobileClient, err error) {
+func (c *MobileClients) Create(mobileClient *v1alpha1.MobileClient) (result *v1alpha1.MobileClient, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(mobileclientsResource, c.ns, mobileClient), &v1alpha1.MobileClient{})
 
@@ -88,7 +88,7 @@ func (c *FakeMobileClients) Create(mobileClient *v1alpha1.MobileClient) (result 
 }
 
 // Update takes the representation of a mobileClient and updates it. Returns the server's representation of the mobileClient, and an error, if there is any.
-func (c *FakeMobileClients) Update(mobileClient *v1alpha1.MobileClient) (result *v1alpha1.MobileClient, err error) {
+func (c *MobileClients) Update(mobileClient *v1alpha1.MobileClient) (result *v1alpha1.MobileClient, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(mobileclientsResource, c.ns, mobileClient), &v1alpha1.MobileClient{})
 
@@ -99,7 +99,7 @@ func (c *FakeMobileClients) Update(mobileClient *v1alpha1.MobileClient) (result 
 }
 
 // Delete takes name of the mobileClient and deletes it. Returns an error if one occurs.
-func (c *FakeMobileClients) Delete(name string, options *v1.DeleteOptions) error {
+func (c *MobileClients) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(mobileclientsResource, c.ns, name), &v1alpha1.MobileClient{})
 
@@ -107,7 +107,7 @@ func (c *FakeMobileClients) Delete(name string, options *v1.DeleteOptions) error
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeMobileClients) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *MobileClients) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(mobileclientsResource, c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.MobileClientList{})
@@ -115,7 +115,7 @@ func (c *FakeMobileClients) DeleteCollection(options *v1.DeleteOptions, listOpti
 }
 
 // Patch applies the patch and returns the patched mobileClient.
-func (c *FakeMobileClients) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.MobileClient, err error) {
+func (c *MobileClients) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.MobileClient, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(mobileclientsResource, c.ns, name, data, subresources...), &v1alpha1.MobileClient{})
 

--- a/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1/mobile_client.go
+++ b/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1/mobile_client.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/aerogear/mobile-cli/pkg/apis/mobile/v1alpha1"
+	"github.com/aerogear/mobile-cli/pkg/apis/mobile/v1alpha1"
 	"github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/versioned/scheme"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	rest "k8s.io/client-go/rest"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
 )
 
 type MobileV1alpha1Interface interface {

--- a/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1/mobileclient.go
+++ b/pkg/client/mobile/clientset/versioned/typed/mobile/v1alpha1/mobileclient.go
@@ -17,12 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/aerogear/mobile-cli/pkg/apis/mobile/v1alpha1"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/versioned/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/mobile/v1alpha1"
+	"github.com/aerogear/mobile-cli/pkg/client/mobile/clientset/versioned/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // MobileClientsGetter has a method to return a MobileClientInterface.

--- a/pkg/client/servicecatalog/clientset/internalversion/clientset.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/clientset.go
@@ -18,10 +18,10 @@ package internalversion
 
 import (
 	servicecataloginternalversion "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion"
-	glog "github.com/golang/glog"
-	discovery "k8s.io/client-go/discovery"
-	rest "k8s.io/client-go/rest"
-	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"github.com/golang/glog"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 )
 
 type Interface interface {

--- a/pkg/client/servicecatalog/clientset/internalversion/fake/clientset_generated.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/fake/clientset_generated.go
@@ -27,11 +27,11 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientSet returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+func NewSimpleClientSet(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -62,5 +62,5 @@ var _ clientset.Interface = &Clientset{}
 
 // Servicecatalog retrieves the ServicecatalogClient
 func (c *Clientset) Servicecatalog() servicecataloginternalversion.ServicecatalogInterface {
-	return &fakeservicecataloginternalversion.FakeServicecatalog{Fake: &c.Fake}
+	return &fakeservicecataloginternalversion.Servicecatalog{Fake: &c.Fake}
 }

--- a/pkg/client/servicecatalog/clientset/internalversion/fake/register.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/fake/register.go
@@ -18,15 +18,14 @@ package fake
 
 import (
 	servicecataloginternalversion "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-var parameterCodec = runtime.NewParameterCodec(scheme)
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})

--- a/pkg/client/servicecatalog/clientset/internalversion/scheme/register.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/scheme/register.go
@@ -18,13 +18,13 @@ package scheme
 
 import (
 	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/install"
-	announced "k8s.io/apimachinery/pkg/apimachinery/announced"
-	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	os "os"
+	"k8s.io/apimachinery/pkg/apimachinery/announced"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"os"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/clusterservicebroker.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/clusterservicebroker.go
@@ -17,12 +17,12 @@ limitations under the License.
 package internalversion
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ClusterServiceBrokersGetter has a method to return a ClusterServiceBrokerInterface.

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/clusterserviceclass.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/clusterserviceclass.go
@@ -17,12 +17,12 @@ limitations under the License.
 package internalversion
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ClusterServiceClassesGetter has a method to return a ClusterServiceClassInterface.

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/clusterserviceplan.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/clusterserviceplan.go
@@ -17,12 +17,12 @@ limitations under the License.
 package internalversion
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ClusterServicePlansGetter has a method to return a ClusterServicePlanInterface.

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_clusterservicebroker.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_clusterservicebroker.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeClusterServiceBrokers implements ClusterServiceBrokerInterface
-type FakeClusterServiceBrokers struct {
-	Fake *FakeServicecatalog
+// ClusterServiceBrokers implements ClusterServiceBrokerInterface
+type ClusterServiceBrokers struct {
+	Fake *Servicecatalog
 }
 
 var clusterservicebrokersResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "", Resource: "clusterservicebrokers"}
@@ -36,7 +36,7 @@ var clusterservicebrokersResource = schema.GroupVersionResource{Group: "servicec
 var clusterservicebrokersKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "", Kind: "ClusterServiceBroker"}
 
 // Get takes name of the clusterServiceBroker, and returns the corresponding clusterServiceBroker object, and an error if there is any.
-func (c *FakeClusterServiceBrokers) Get(name string, options v1.GetOptions) (result *servicecatalog.ClusterServiceBroker, err error) {
+func (c *ClusterServiceBrokers) Get(name string, options v1.GetOptions) (result *servicecatalog.ClusterServiceBroker, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterservicebrokersResource, name), &servicecatalog.ClusterServiceBroker{})
 	if obj == nil {
@@ -46,7 +46,7 @@ func (c *FakeClusterServiceBrokers) Get(name string, options v1.GetOptions) (res
 }
 
 // List takes label and field selectors, and returns the list of ClusterServiceBrokers that match those selectors.
-func (c *FakeClusterServiceBrokers) List(opts v1.ListOptions) (result *servicecatalog.ClusterServiceBrokerList, err error) {
+func (c *ClusterServiceBrokers) List(opts v1.ListOptions) (result *servicecatalog.ClusterServiceBrokerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterservicebrokersResource, clusterservicebrokersKind, opts), &servicecatalog.ClusterServiceBrokerList{})
 	if obj == nil {
@@ -67,13 +67,13 @@ func (c *FakeClusterServiceBrokers) List(opts v1.ListOptions) (result *serviceca
 }
 
 // Watch returns a watch.Interface that watches the requested clusterServiceBrokers.
-func (c *FakeClusterServiceBrokers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ClusterServiceBrokers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterservicebrokersResource, opts))
 }
 
 // Create takes the representation of a clusterServiceBroker and creates it.  Returns the server's representation of the clusterServiceBroker, and an error, if there is any.
-func (c *FakeClusterServiceBrokers) Create(clusterServiceBroker *servicecatalog.ClusterServiceBroker) (result *servicecatalog.ClusterServiceBroker, err error) {
+func (c *ClusterServiceBrokers) Create(clusterServiceBroker *servicecatalog.ClusterServiceBroker) (result *servicecatalog.ClusterServiceBroker, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterservicebrokersResource, clusterServiceBroker), &servicecatalog.ClusterServiceBroker{})
 	if obj == nil {
@@ -83,7 +83,7 @@ func (c *FakeClusterServiceBrokers) Create(clusterServiceBroker *servicecatalog.
 }
 
 // Update takes the representation of a clusterServiceBroker and updates it. Returns the server's representation of the clusterServiceBroker, and an error, if there is any.
-func (c *FakeClusterServiceBrokers) Update(clusterServiceBroker *servicecatalog.ClusterServiceBroker) (result *servicecatalog.ClusterServiceBroker, err error) {
+func (c *ClusterServiceBrokers) Update(clusterServiceBroker *servicecatalog.ClusterServiceBroker) (result *servicecatalog.ClusterServiceBroker, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterservicebrokersResource, clusterServiceBroker), &servicecatalog.ClusterServiceBroker{})
 	if obj == nil {
@@ -94,7 +94,7 @@ func (c *FakeClusterServiceBrokers) Update(clusterServiceBroker *servicecatalog.
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeClusterServiceBrokers) UpdateStatus(clusterServiceBroker *servicecatalog.ClusterServiceBroker) (*servicecatalog.ClusterServiceBroker, error) {
+func (c *ClusterServiceBrokers) UpdateStatus(clusterServiceBroker *servicecatalog.ClusterServiceBroker) (*servicecatalog.ClusterServiceBroker, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(clusterservicebrokersResource, "status", clusterServiceBroker), &servicecatalog.ClusterServiceBroker{})
 	if obj == nil {
@@ -104,14 +104,14 @@ func (c *FakeClusterServiceBrokers) UpdateStatus(clusterServiceBroker *serviceca
 }
 
 // Delete takes name of the clusterServiceBroker and deletes it. Returns an error if one occurs.
-func (c *FakeClusterServiceBrokers) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ClusterServiceBrokers) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterservicebrokersResource, name), &servicecatalog.ClusterServiceBroker{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeClusterServiceBrokers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ClusterServiceBrokers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterservicebrokersResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &servicecatalog.ClusterServiceBrokerList{})
@@ -119,7 +119,7 @@ func (c *FakeClusterServiceBrokers) DeleteCollection(options *v1.DeleteOptions, 
 }
 
 // Patch applies the patch and returns the patched clusterServiceBroker.
-func (c *FakeClusterServiceBrokers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ClusterServiceBroker, err error) {
+func (c *ClusterServiceBrokers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ClusterServiceBroker, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootPatchSubresourceAction(clusterservicebrokersResource, name, data, subresources...), &servicecatalog.ClusterServiceBroker{})
 	if obj == nil {

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_clusterserviceclass.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_clusterserviceclass.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeClusterServiceClasses implements ClusterServiceClassInterface
-type FakeClusterServiceClasses struct {
-	Fake *FakeServicecatalog
+// ClusterServiceClasses implements ClusterServiceClassInterface
+type ClusterServiceClasses struct {
+	Fake *Servicecatalog
 }
 
 var clusterserviceclassesResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "", Resource: "clusterserviceclasses"}
@@ -36,7 +36,7 @@ var clusterserviceclassesResource = schema.GroupVersionResource{Group: "servicec
 var clusterserviceclassesKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "", Kind: "ClusterServiceClass"}
 
 // Get takes name of the clusterServiceClass, and returns the corresponding clusterServiceClass object, and an error if there is any.
-func (c *FakeClusterServiceClasses) Get(name string, options v1.GetOptions) (result *servicecatalog.ClusterServiceClass, err error) {
+func (c *ClusterServiceClasses) Get(name string, options v1.GetOptions) (result *servicecatalog.ClusterServiceClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterserviceclassesResource, name), &servicecatalog.ClusterServiceClass{})
 	if obj == nil {
@@ -46,7 +46,7 @@ func (c *FakeClusterServiceClasses) Get(name string, options v1.GetOptions) (res
 }
 
 // List takes label and field selectors, and returns the list of ClusterServiceClasses that match those selectors.
-func (c *FakeClusterServiceClasses) List(opts v1.ListOptions) (result *servicecatalog.ClusterServiceClassList, err error) {
+func (c *ClusterServiceClasses) List(opts v1.ListOptions) (result *servicecatalog.ClusterServiceClassList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterserviceclassesResource, clusterserviceclassesKind, opts), &servicecatalog.ClusterServiceClassList{})
 	if obj == nil {
@@ -67,13 +67,13 @@ func (c *FakeClusterServiceClasses) List(opts v1.ListOptions) (result *serviceca
 }
 
 // Watch returns a watch.Interface that watches the requested clusterServiceClasses.
-func (c *FakeClusterServiceClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ClusterServiceClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterserviceclassesResource, opts))
 }
 
 // Create takes the representation of a clusterServiceClass and creates it.  Returns the server's representation of the clusterServiceClass, and an error, if there is any.
-func (c *FakeClusterServiceClasses) Create(clusterServiceClass *servicecatalog.ClusterServiceClass) (result *servicecatalog.ClusterServiceClass, err error) {
+func (c *ClusterServiceClasses) Create(clusterServiceClass *servicecatalog.ClusterServiceClass) (result *servicecatalog.ClusterServiceClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterserviceclassesResource, clusterServiceClass), &servicecatalog.ClusterServiceClass{})
 	if obj == nil {
@@ -83,7 +83,7 @@ func (c *FakeClusterServiceClasses) Create(clusterServiceClass *servicecatalog.C
 }
 
 // Update takes the representation of a clusterServiceClass and updates it. Returns the server's representation of the clusterServiceClass, and an error, if there is any.
-func (c *FakeClusterServiceClasses) Update(clusterServiceClass *servicecatalog.ClusterServiceClass) (result *servicecatalog.ClusterServiceClass, err error) {
+func (c *ClusterServiceClasses) Update(clusterServiceClass *servicecatalog.ClusterServiceClass) (result *servicecatalog.ClusterServiceClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterserviceclassesResource, clusterServiceClass), &servicecatalog.ClusterServiceClass{})
 	if obj == nil {
@@ -94,7 +94,7 @@ func (c *FakeClusterServiceClasses) Update(clusterServiceClass *servicecatalog.C
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeClusterServiceClasses) UpdateStatus(clusterServiceClass *servicecatalog.ClusterServiceClass) (*servicecatalog.ClusterServiceClass, error) {
+func (c *ClusterServiceClasses) UpdateStatus(clusterServiceClass *servicecatalog.ClusterServiceClass) (*servicecatalog.ClusterServiceClass, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(clusterserviceclassesResource, "status", clusterServiceClass), &servicecatalog.ClusterServiceClass{})
 	if obj == nil {
@@ -104,14 +104,14 @@ func (c *FakeClusterServiceClasses) UpdateStatus(clusterServiceClass *servicecat
 }
 
 // Delete takes name of the clusterServiceClass and deletes it. Returns an error if one occurs.
-func (c *FakeClusterServiceClasses) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ClusterServiceClasses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterserviceclassesResource, name), &servicecatalog.ClusterServiceClass{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeClusterServiceClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ClusterServiceClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterserviceclassesResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &servicecatalog.ClusterServiceClassList{})
@@ -119,7 +119,7 @@ func (c *FakeClusterServiceClasses) DeleteCollection(options *v1.DeleteOptions, 
 }
 
 // Patch applies the patch and returns the patched clusterServiceClass.
-func (c *FakeClusterServiceClasses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ClusterServiceClass, err error) {
+func (c *ClusterServiceClasses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ClusterServiceClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootPatchSubresourceAction(clusterserviceclassesResource, name, data, subresources...), &servicecatalog.ClusterServiceClass{})
 	if obj == nil {

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_clusterserviceplan.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_clusterserviceplan.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeClusterServicePlans implements ClusterServicePlanInterface
-type FakeClusterServicePlans struct {
-	Fake *FakeServicecatalog
+// ClusterServicePlans implements ClusterServicePlanInterface
+type ClusterServicePlans struct {
+	Fake *Servicecatalog
 }
 
 var clusterserviceplansResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "", Resource: "clusterserviceplans"}
@@ -36,7 +36,7 @@ var clusterserviceplansResource = schema.GroupVersionResource{Group: "servicecat
 var clusterserviceplansKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "", Kind: "ClusterServicePlan"}
 
 // Get takes name of the clusterServicePlan, and returns the corresponding clusterServicePlan object, and an error if there is any.
-func (c *FakeClusterServicePlans) Get(name string, options v1.GetOptions) (result *servicecatalog.ClusterServicePlan, err error) {
+func (c *ClusterServicePlans) Get(name string, options v1.GetOptions) (result *servicecatalog.ClusterServicePlan, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterserviceplansResource, name), &servicecatalog.ClusterServicePlan{})
 	if obj == nil {
@@ -46,7 +46,7 @@ func (c *FakeClusterServicePlans) Get(name string, options v1.GetOptions) (resul
 }
 
 // List takes label and field selectors, and returns the list of ClusterServicePlans that match those selectors.
-func (c *FakeClusterServicePlans) List(opts v1.ListOptions) (result *servicecatalog.ClusterServicePlanList, err error) {
+func (c *ClusterServicePlans) List(opts v1.ListOptions) (result *servicecatalog.ClusterServicePlanList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterserviceplansResource, clusterserviceplansKind, opts), &servicecatalog.ClusterServicePlanList{})
 	if obj == nil {
@@ -67,13 +67,13 @@ func (c *FakeClusterServicePlans) List(opts v1.ListOptions) (result *servicecata
 }
 
 // Watch returns a watch.Interface that watches the requested clusterServicePlans.
-func (c *FakeClusterServicePlans) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ClusterServicePlans) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterserviceplansResource, opts))
 }
 
 // Create takes the representation of a clusterServicePlan and creates it.  Returns the server's representation of the clusterServicePlan, and an error, if there is any.
-func (c *FakeClusterServicePlans) Create(clusterServicePlan *servicecatalog.ClusterServicePlan) (result *servicecatalog.ClusterServicePlan, err error) {
+func (c *ClusterServicePlans) Create(clusterServicePlan *servicecatalog.ClusterServicePlan) (result *servicecatalog.ClusterServicePlan, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterserviceplansResource, clusterServicePlan), &servicecatalog.ClusterServicePlan{})
 	if obj == nil {
@@ -83,7 +83,7 @@ func (c *FakeClusterServicePlans) Create(clusterServicePlan *servicecatalog.Clus
 }
 
 // Update takes the representation of a clusterServicePlan and updates it. Returns the server's representation of the clusterServicePlan, and an error, if there is any.
-func (c *FakeClusterServicePlans) Update(clusterServicePlan *servicecatalog.ClusterServicePlan) (result *servicecatalog.ClusterServicePlan, err error) {
+func (c *ClusterServicePlans) Update(clusterServicePlan *servicecatalog.ClusterServicePlan) (result *servicecatalog.ClusterServicePlan, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterserviceplansResource, clusterServicePlan), &servicecatalog.ClusterServicePlan{})
 	if obj == nil {
@@ -94,7 +94,7 @@ func (c *FakeClusterServicePlans) Update(clusterServicePlan *servicecatalog.Clus
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeClusterServicePlans) UpdateStatus(clusterServicePlan *servicecatalog.ClusterServicePlan) (*servicecatalog.ClusterServicePlan, error) {
+func (c *ClusterServicePlans) UpdateStatus(clusterServicePlan *servicecatalog.ClusterServicePlan) (*servicecatalog.ClusterServicePlan, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(clusterserviceplansResource, "status", clusterServicePlan), &servicecatalog.ClusterServicePlan{})
 	if obj == nil {
@@ -104,14 +104,14 @@ func (c *FakeClusterServicePlans) UpdateStatus(clusterServicePlan *servicecatalo
 }
 
 // Delete takes name of the clusterServicePlan and deletes it. Returns an error if one occurs.
-func (c *FakeClusterServicePlans) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ClusterServicePlans) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterserviceplansResource, name), &servicecatalog.ClusterServicePlan{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeClusterServicePlans) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ClusterServicePlans) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterserviceplansResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &servicecatalog.ClusterServicePlanList{})
@@ -119,7 +119,7 @@ func (c *FakeClusterServicePlans) DeleteCollection(options *v1.DeleteOptions, li
 }
 
 // Patch applies the patch and returns the patched clusterServicePlan.
-func (c *FakeClusterServicePlans) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ClusterServicePlan, err error) {
+func (c *ClusterServicePlans) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ClusterServicePlan, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootPatchSubresourceAction(clusterserviceplansResource, name, data, subresources...), &servicecatalog.ClusterServicePlan{})
 	if obj == nil {

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_servicebinding.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_servicebinding.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeServiceBindings implements ServiceBindingInterface
-type FakeServiceBindings struct {
-	Fake *FakeServicecatalog
+// ServiceBindings implements ServiceBindingInterface
+type ServiceBindings struct {
+	Fake *Servicecatalog
 	ns   string
 }
 
@@ -37,7 +37,7 @@ var servicebindingsResource = schema.GroupVersionResource{Group: "servicecatalog
 var servicebindingsKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "", Kind: "ServiceBinding"}
 
 // Get takes name of the serviceBinding, and returns the corresponding serviceBinding object, and an error if there is any.
-func (c *FakeServiceBindings) Get(name string, options v1.GetOptions) (result *servicecatalog.ServiceBinding, err error) {
+func (c *ServiceBindings) Get(name string, options v1.GetOptions) (result *servicecatalog.ServiceBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(servicebindingsResource, c.ns, name), &servicecatalog.ServiceBinding{})
 
@@ -48,7 +48,7 @@ func (c *FakeServiceBindings) Get(name string, options v1.GetOptions) (result *s
 }
 
 // List takes label and field selectors, and returns the list of ServiceBindings that match those selectors.
-func (c *FakeServiceBindings) List(opts v1.ListOptions) (result *servicecatalog.ServiceBindingList, err error) {
+func (c *ServiceBindings) List(opts v1.ListOptions) (result *servicecatalog.ServiceBindingList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(servicebindingsResource, servicebindingsKind, c.ns, opts), &servicecatalog.ServiceBindingList{})
 
@@ -70,14 +70,14 @@ func (c *FakeServiceBindings) List(opts v1.ListOptions) (result *servicecatalog.
 }
 
 // Watch returns a watch.Interface that watches the requested serviceBindings.
-func (c *FakeServiceBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ServiceBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(servicebindingsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a serviceBinding and creates it.  Returns the server's representation of the serviceBinding, and an error, if there is any.
-func (c *FakeServiceBindings) Create(serviceBinding *servicecatalog.ServiceBinding) (result *servicecatalog.ServiceBinding, err error) {
+func (c *ServiceBindings) Create(serviceBinding *servicecatalog.ServiceBinding) (result *servicecatalog.ServiceBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(servicebindingsResource, c.ns, serviceBinding), &servicecatalog.ServiceBinding{})
 
@@ -88,7 +88,7 @@ func (c *FakeServiceBindings) Create(serviceBinding *servicecatalog.ServiceBindi
 }
 
 // Update takes the representation of a serviceBinding and updates it. Returns the server's representation of the serviceBinding, and an error, if there is any.
-func (c *FakeServiceBindings) Update(serviceBinding *servicecatalog.ServiceBinding) (result *servicecatalog.ServiceBinding, err error) {
+func (c *ServiceBindings) Update(serviceBinding *servicecatalog.ServiceBinding) (result *servicecatalog.ServiceBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(servicebindingsResource, c.ns, serviceBinding), &servicecatalog.ServiceBinding{})
 
@@ -100,7 +100,7 @@ func (c *FakeServiceBindings) Update(serviceBinding *servicecatalog.ServiceBindi
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeServiceBindings) UpdateStatus(serviceBinding *servicecatalog.ServiceBinding) (*servicecatalog.ServiceBinding, error) {
+func (c *ServiceBindings) UpdateStatus(serviceBinding *servicecatalog.ServiceBinding) (*servicecatalog.ServiceBinding, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(servicebindingsResource, "status", c.ns, serviceBinding), &servicecatalog.ServiceBinding{})
 
@@ -111,7 +111,7 @@ func (c *FakeServiceBindings) UpdateStatus(serviceBinding *servicecatalog.Servic
 }
 
 // Delete takes name of the serviceBinding and deletes it. Returns an error if one occurs.
-func (c *FakeServiceBindings) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ServiceBindings) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(servicebindingsResource, c.ns, name), &servicecatalog.ServiceBinding{})
 
@@ -119,7 +119,7 @@ func (c *FakeServiceBindings) Delete(name string, options *v1.DeleteOptions) err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeServiceBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ServiceBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(servicebindingsResource, c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &servicecatalog.ServiceBindingList{})
@@ -127,7 +127,7 @@ func (c *FakeServiceBindings) DeleteCollection(options *v1.DeleteOptions, listOp
 }
 
 // Patch applies the patch and returns the patched serviceBinding.
-func (c *FakeServiceBindings) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ServiceBinding, err error) {
+func (c *ServiceBindings) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ServiceBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(servicebindingsResource, c.ns, name, data, subresources...), &servicecatalog.ServiceBinding{})
 

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_servicecatalog_client.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_servicecatalog_client.go
@@ -17,38 +17,38 @@ limitations under the License.
 package fake
 
 import (
-	internalversion "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion"
-	rest "k8s.io/client-go/rest"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/testing"
 )
 
-type FakeServicecatalog struct {
+type Servicecatalog struct {
 	*testing.Fake
 }
 
-func (c *FakeServicecatalog) ClusterServiceBrokers() internalversion.ClusterServiceBrokerInterface {
-	return &FakeClusterServiceBrokers{c}
+func (c *Servicecatalog) ClusterServiceBrokers() internalversion.ClusterServiceBrokerInterface {
+	return &ClusterServiceBrokers{c}
 }
 
-func (c *FakeServicecatalog) ClusterServiceClasses() internalversion.ClusterServiceClassInterface {
-	return &FakeClusterServiceClasses{c}
+func (c *Servicecatalog) ClusterServiceClasses() internalversion.ClusterServiceClassInterface {
+	return &ClusterServiceClasses{c}
 }
 
-func (c *FakeServicecatalog) ClusterServicePlans() internalversion.ClusterServicePlanInterface {
-	return &FakeClusterServicePlans{c}
+func (c *Servicecatalog) ClusterServicePlans() internalversion.ClusterServicePlanInterface {
+	return &ClusterServicePlans{c}
 }
 
-func (c *FakeServicecatalog) ServiceBindings(namespace string) internalversion.ServiceBindingInterface {
-	return &FakeServiceBindings{c, namespace}
+func (c *Servicecatalog) ServiceBindings(namespace string) internalversion.ServiceBindingInterface {
+	return &ServiceBindings{c, namespace}
 }
 
-func (c *FakeServicecatalog) ServiceInstances(namespace string) internalversion.ServiceInstanceInterface {
-	return &FakeServiceInstances{c, namespace}
+func (c *Servicecatalog) ServiceInstances(namespace string) internalversion.ServiceInstanceInterface {
+	return &ServiceInstances{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeServicecatalog) RESTClient() rest.Interface {
+func (c *Servicecatalog) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_serviceinstance.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/fake/fake_serviceinstance.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeServiceInstances implements ServiceInstanceInterface
-type FakeServiceInstances struct {
-	Fake *FakeServicecatalog
+// ServiceInstances implements ServiceInstanceInterface
+type ServiceInstances struct {
+	Fake *Servicecatalog
 	ns   string
 }
 
@@ -37,7 +37,7 @@ var serviceinstancesResource = schema.GroupVersionResource{Group: "servicecatalo
 var serviceinstancesKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "", Kind: "ServiceInstance"}
 
 // Get takes name of the serviceInstance, and returns the corresponding serviceInstance object, and an error if there is any.
-func (c *FakeServiceInstances) Get(name string, options v1.GetOptions) (result *servicecatalog.ServiceInstance, err error) {
+func (c *ServiceInstances) Get(name string, options v1.GetOptions) (result *servicecatalog.ServiceInstance, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(serviceinstancesResource, c.ns, name), &servicecatalog.ServiceInstance{})
 
@@ -48,7 +48,7 @@ func (c *FakeServiceInstances) Get(name string, options v1.GetOptions) (result *
 }
 
 // List takes label and field selectors, and returns the list of ServiceInstances that match those selectors.
-func (c *FakeServiceInstances) List(opts v1.ListOptions) (result *servicecatalog.ServiceInstanceList, err error) {
+func (c *ServiceInstances) List(opts v1.ListOptions) (result *servicecatalog.ServiceInstanceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(serviceinstancesResource, serviceinstancesKind, c.ns, opts), &servicecatalog.ServiceInstanceList{})
 
@@ -70,14 +70,14 @@ func (c *FakeServiceInstances) List(opts v1.ListOptions) (result *servicecatalog
 }
 
 // Watch returns a watch.Interface that watches the requested serviceInstances.
-func (c *FakeServiceInstances) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ServiceInstances) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(serviceinstancesResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a serviceInstance and creates it.  Returns the server's representation of the serviceInstance, and an error, if there is any.
-func (c *FakeServiceInstances) Create(serviceInstance *servicecatalog.ServiceInstance) (result *servicecatalog.ServiceInstance, err error) {
+func (c *ServiceInstances) Create(serviceInstance *servicecatalog.ServiceInstance) (result *servicecatalog.ServiceInstance, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(serviceinstancesResource, c.ns, serviceInstance), &servicecatalog.ServiceInstance{})
 
@@ -88,7 +88,7 @@ func (c *FakeServiceInstances) Create(serviceInstance *servicecatalog.ServiceIns
 }
 
 // Update takes the representation of a serviceInstance and updates it. Returns the server's representation of the serviceInstance, and an error, if there is any.
-func (c *FakeServiceInstances) Update(serviceInstance *servicecatalog.ServiceInstance) (result *servicecatalog.ServiceInstance, err error) {
+func (c *ServiceInstances) Update(serviceInstance *servicecatalog.ServiceInstance) (result *servicecatalog.ServiceInstance, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(serviceinstancesResource, c.ns, serviceInstance), &servicecatalog.ServiceInstance{})
 
@@ -100,7 +100,7 @@ func (c *FakeServiceInstances) Update(serviceInstance *servicecatalog.ServiceIns
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeServiceInstances) UpdateStatus(serviceInstance *servicecatalog.ServiceInstance) (*servicecatalog.ServiceInstance, error) {
+func (c *ServiceInstances) UpdateStatus(serviceInstance *servicecatalog.ServiceInstance) (*servicecatalog.ServiceInstance, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(serviceinstancesResource, "status", c.ns, serviceInstance), &servicecatalog.ServiceInstance{})
 
@@ -111,7 +111,7 @@ func (c *FakeServiceInstances) UpdateStatus(serviceInstance *servicecatalog.Serv
 }
 
 // Delete takes name of the serviceInstance and deletes it. Returns an error if one occurs.
-func (c *FakeServiceInstances) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ServiceInstances) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(serviceinstancesResource, c.ns, name), &servicecatalog.ServiceInstance{})
 
@@ -119,7 +119,7 @@ func (c *FakeServiceInstances) Delete(name string, options *v1.DeleteOptions) er
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeServiceInstances) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ServiceInstances) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(serviceinstancesResource, c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &servicecatalog.ServiceInstanceList{})
@@ -127,7 +127,7 @@ func (c *FakeServiceInstances) DeleteCollection(options *v1.DeleteOptions, listO
 }
 
 // Patch applies the patch and returns the patched serviceInstance.
-func (c *FakeServiceInstances) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ServiceInstance, err error) {
+func (c *ServiceInstances) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *servicecatalog.ServiceInstance, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(serviceinstancesResource, c.ns, name, data, subresources...), &servicecatalog.ServiceInstance{})
 

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/servicebinding.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/servicebinding.go
@@ -17,12 +17,12 @@ limitations under the License.
 package internalversion
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ServiceBindingsGetter has a method to return a ServiceBindingInterface.

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/servicecatalog_client.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/servicecatalog_client.go
@@ -18,7 +18,7 @@ package internalversion
 
 import (
 	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
-	rest "k8s.io/client-go/rest"
+	"k8s.io/client-go/rest"
 )
 
 type ServicecatalogInterface interface {

--- a/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/serviceinstance.go
+++ b/pkg/client/servicecatalog/clientset/internalversion/typed/servicecatalog/internalversion/serviceinstance.go
@@ -17,12 +17,12 @@ limitations under the License.
 package internalversion
 
 import (
-	servicecatalog "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/internalversion/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ServiceInstancesGetter has a method to return a ServiceInstanceInterface.

--- a/pkg/client/servicecatalog/clientset/versioned/clientset.go
+++ b/pkg/client/servicecatalog/clientset/versioned/clientset.go
@@ -18,10 +18,10 @@ package versioned
 
 import (
 	servicecatalogv1beta1 "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1"
-	glog "github.com/golang/glog"
-	discovery "k8s.io/client-go/discovery"
-	rest "k8s.io/client-go/rest"
-	flowcontrol "k8s.io/client-go/util/flowcontrol"
+	"github.com/golang/glog"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 )
 
 type Interface interface {

--- a/pkg/client/servicecatalog/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/servicecatalog/clientset/versioned/fake/clientset_generated.go
@@ -27,11 +27,11 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientSet returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+func NewSimpleClientSet(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -62,10 +62,10 @@ var _ clientset.Interface = &Clientset{}
 
 // ServicecatalogV1beta1 retrieves the ServicecatalogV1beta1Client
 func (c *Clientset) ServicecatalogV1beta1() servicecatalogv1beta1.ServicecatalogV1beta1Interface {
-	return &fakeservicecatalogv1beta1.FakeServicecatalogV1beta1{Fake: &c.Fake}
+	return &fakeservicecatalogv1beta1.ServicecatalogV1beta1{Fake: &c.Fake}
 }
 
 // Servicecatalog retrieves the ServicecatalogV1beta1Client
 func (c *Clientset) Servicecatalog() servicecatalogv1beta1.ServicecatalogV1beta1Interface {
-	return &fakeservicecatalogv1beta1.FakeServicecatalogV1beta1{Fake: &c.Fake}
+	return &fakeservicecatalogv1beta1.ServicecatalogV1beta1{Fake: &c.Fake}
 }

--- a/pkg/client/servicecatalog/clientset/versioned/fake/register.go
+++ b/pkg/client/servicecatalog/clientset/versioned/fake/register.go
@@ -18,15 +18,14 @@ package fake
 
 import (
 	servicecatalogv1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-var parameterCodec = runtime.NewParameterCodec(scheme)
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})

--- a/pkg/client/servicecatalog/clientset/versioned/scheme/register.go
+++ b/pkg/client/servicecatalog/clientset/versioned/scheme/register.go
@@ -18,10 +18,10 @@ package scheme
 
 import (
 	servicecatalogv1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/clusterservicebroker.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/clusterservicebroker.go
@@ -17,12 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ClusterServiceBrokersGetter has a method to return a ClusterServiceBrokerInterface.

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/clusterserviceclass.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/clusterserviceclass.go
@@ -17,12 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ClusterServiceClassesGetter has a method to return a ClusterServiceClassInterface.

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/clusterserviceplan.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/clusterserviceplan.go
@@ -17,12 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ClusterServicePlansGetter has a method to return a ClusterServicePlanInterface.

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_clusterservicebroker.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_clusterservicebroker.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeClusterServiceBrokers implements ClusterServiceBrokerInterface
-type FakeClusterServiceBrokers struct {
-	Fake *FakeServicecatalogV1beta1
+// ClusterServiceBrokers implements ClusterServiceBrokerInterface
+type ClusterServiceBrokers struct {
+	Fake *ServicecatalogV1beta1
 }
 
 var clusterservicebrokersResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "v1beta1", Resource: "clusterservicebrokers"}
@@ -36,7 +36,7 @@ var clusterservicebrokersResource = schema.GroupVersionResource{Group: "servicec
 var clusterservicebrokersKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "v1beta1", Kind: "ClusterServiceBroker"}
 
 // Get takes name of the clusterServiceBroker, and returns the corresponding clusterServiceBroker object, and an error if there is any.
-func (c *FakeClusterServiceBrokers) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterServiceBroker, err error) {
+func (c *ClusterServiceBrokers) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterServiceBroker, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterservicebrokersResource, name), &v1beta1.ClusterServiceBroker{})
 	if obj == nil {
@@ -46,7 +46,7 @@ func (c *FakeClusterServiceBrokers) Get(name string, options v1.GetOptions) (res
 }
 
 // List takes label and field selectors, and returns the list of ClusterServiceBrokers that match those selectors.
-func (c *FakeClusterServiceBrokers) List(opts v1.ListOptions) (result *v1beta1.ClusterServiceBrokerList, err error) {
+func (c *ClusterServiceBrokers) List(opts v1.ListOptions) (result *v1beta1.ClusterServiceBrokerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterservicebrokersResource, clusterservicebrokersKind, opts), &v1beta1.ClusterServiceBrokerList{})
 	if obj == nil {
@@ -67,13 +67,13 @@ func (c *FakeClusterServiceBrokers) List(opts v1.ListOptions) (result *v1beta1.C
 }
 
 // Watch returns a watch.Interface that watches the requested clusterServiceBrokers.
-func (c *FakeClusterServiceBrokers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ClusterServiceBrokers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterservicebrokersResource, opts))
 }
 
 // Create takes the representation of a clusterServiceBroker and creates it.  Returns the server's representation of the clusterServiceBroker, and an error, if there is any.
-func (c *FakeClusterServiceBrokers) Create(clusterServiceBroker *v1beta1.ClusterServiceBroker) (result *v1beta1.ClusterServiceBroker, err error) {
+func (c *ClusterServiceBrokers) Create(clusterServiceBroker *v1beta1.ClusterServiceBroker) (result *v1beta1.ClusterServiceBroker, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterservicebrokersResource, clusterServiceBroker), &v1beta1.ClusterServiceBroker{})
 	if obj == nil {
@@ -83,7 +83,7 @@ func (c *FakeClusterServiceBrokers) Create(clusterServiceBroker *v1beta1.Cluster
 }
 
 // Update takes the representation of a clusterServiceBroker and updates it. Returns the server's representation of the clusterServiceBroker, and an error, if there is any.
-func (c *FakeClusterServiceBrokers) Update(clusterServiceBroker *v1beta1.ClusterServiceBroker) (result *v1beta1.ClusterServiceBroker, err error) {
+func (c *ClusterServiceBrokers) Update(clusterServiceBroker *v1beta1.ClusterServiceBroker) (result *v1beta1.ClusterServiceBroker, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterservicebrokersResource, clusterServiceBroker), &v1beta1.ClusterServiceBroker{})
 	if obj == nil {
@@ -94,7 +94,7 @@ func (c *FakeClusterServiceBrokers) Update(clusterServiceBroker *v1beta1.Cluster
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeClusterServiceBrokers) UpdateStatus(clusterServiceBroker *v1beta1.ClusterServiceBroker) (*v1beta1.ClusterServiceBroker, error) {
+func (c *ClusterServiceBrokers) UpdateStatus(clusterServiceBroker *v1beta1.ClusterServiceBroker) (*v1beta1.ClusterServiceBroker, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(clusterservicebrokersResource, "status", clusterServiceBroker), &v1beta1.ClusterServiceBroker{})
 	if obj == nil {
@@ -104,14 +104,14 @@ func (c *FakeClusterServiceBrokers) UpdateStatus(clusterServiceBroker *v1beta1.C
 }
 
 // Delete takes name of the clusterServiceBroker and deletes it. Returns an error if one occurs.
-func (c *FakeClusterServiceBrokers) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ClusterServiceBrokers) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterservicebrokersResource, name), &v1beta1.ClusterServiceBroker{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeClusterServiceBrokers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ClusterServiceBrokers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterservicebrokersResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ClusterServiceBrokerList{})
@@ -119,7 +119,7 @@ func (c *FakeClusterServiceBrokers) DeleteCollection(options *v1.DeleteOptions, 
 }
 
 // Patch applies the patch and returns the patched clusterServiceBroker.
-func (c *FakeClusterServiceBrokers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ClusterServiceBroker, err error) {
+func (c *ClusterServiceBrokers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ClusterServiceBroker, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootPatchSubresourceAction(clusterservicebrokersResource, name, data, subresources...), &v1beta1.ClusterServiceBroker{})
 	if obj == nil {

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_clusterserviceclass.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_clusterserviceclass.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeClusterServiceClasses implements ClusterServiceClassInterface
-type FakeClusterServiceClasses struct {
-	Fake *FakeServicecatalogV1beta1
+// ClusterServiceClasses implements ClusterServiceClassInterface
+type ClusterServiceClasses struct {
+	Fake *ServicecatalogV1beta1
 }
 
 var clusterserviceclassesResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "v1beta1", Resource: "clusterserviceclasses"}
@@ -36,7 +36,7 @@ var clusterserviceclassesResource = schema.GroupVersionResource{Group: "servicec
 var clusterserviceclassesKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "v1beta1", Kind: "ClusterServiceClass"}
 
 // Get takes name of the clusterServiceClass, and returns the corresponding clusterServiceClass object, and an error if there is any.
-func (c *FakeClusterServiceClasses) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterServiceClass, err error) {
+func (c *ClusterServiceClasses) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterServiceClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterserviceclassesResource, name), &v1beta1.ClusterServiceClass{})
 	if obj == nil {
@@ -46,7 +46,7 @@ func (c *FakeClusterServiceClasses) Get(name string, options v1.GetOptions) (res
 }
 
 // List takes label and field selectors, and returns the list of ClusterServiceClasses that match those selectors.
-func (c *FakeClusterServiceClasses) List(opts v1.ListOptions) (result *v1beta1.ClusterServiceClassList, err error) {
+func (c *ClusterServiceClasses) List(opts v1.ListOptions) (result *v1beta1.ClusterServiceClassList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterserviceclassesResource, clusterserviceclassesKind, opts), &v1beta1.ClusterServiceClassList{})
 	if obj == nil {
@@ -67,13 +67,13 @@ func (c *FakeClusterServiceClasses) List(opts v1.ListOptions) (result *v1beta1.C
 }
 
 // Watch returns a watch.Interface that watches the requested clusterServiceClasses.
-func (c *FakeClusterServiceClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ClusterServiceClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterserviceclassesResource, opts))
 }
 
 // Create takes the representation of a clusterServiceClass and creates it.  Returns the server's representation of the clusterServiceClass, and an error, if there is any.
-func (c *FakeClusterServiceClasses) Create(clusterServiceClass *v1beta1.ClusterServiceClass) (result *v1beta1.ClusterServiceClass, err error) {
+func (c *ClusterServiceClasses) Create(clusterServiceClass *v1beta1.ClusterServiceClass) (result *v1beta1.ClusterServiceClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterserviceclassesResource, clusterServiceClass), &v1beta1.ClusterServiceClass{})
 	if obj == nil {
@@ -83,7 +83,7 @@ func (c *FakeClusterServiceClasses) Create(clusterServiceClass *v1beta1.ClusterS
 }
 
 // Update takes the representation of a clusterServiceClass and updates it. Returns the server's representation of the clusterServiceClass, and an error, if there is any.
-func (c *FakeClusterServiceClasses) Update(clusterServiceClass *v1beta1.ClusterServiceClass) (result *v1beta1.ClusterServiceClass, err error) {
+func (c *ClusterServiceClasses) Update(clusterServiceClass *v1beta1.ClusterServiceClass) (result *v1beta1.ClusterServiceClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterserviceclassesResource, clusterServiceClass), &v1beta1.ClusterServiceClass{})
 	if obj == nil {
@@ -94,7 +94,7 @@ func (c *FakeClusterServiceClasses) Update(clusterServiceClass *v1beta1.ClusterS
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeClusterServiceClasses) UpdateStatus(clusterServiceClass *v1beta1.ClusterServiceClass) (*v1beta1.ClusterServiceClass, error) {
+func (c *ClusterServiceClasses) UpdateStatus(clusterServiceClass *v1beta1.ClusterServiceClass) (*v1beta1.ClusterServiceClass, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(clusterserviceclassesResource, "status", clusterServiceClass), &v1beta1.ClusterServiceClass{})
 	if obj == nil {
@@ -104,14 +104,14 @@ func (c *FakeClusterServiceClasses) UpdateStatus(clusterServiceClass *v1beta1.Cl
 }
 
 // Delete takes name of the clusterServiceClass and deletes it. Returns an error if one occurs.
-func (c *FakeClusterServiceClasses) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ClusterServiceClasses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterserviceclassesResource, name), &v1beta1.ClusterServiceClass{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeClusterServiceClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ClusterServiceClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterserviceclassesResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ClusterServiceClassList{})
@@ -119,7 +119,7 @@ func (c *FakeClusterServiceClasses) DeleteCollection(options *v1.DeleteOptions, 
 }
 
 // Patch applies the patch and returns the patched clusterServiceClass.
-func (c *FakeClusterServiceClasses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ClusterServiceClass, err error) {
+func (c *ClusterServiceClasses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ClusterServiceClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootPatchSubresourceAction(clusterserviceclassesResource, name, data, subresources...), &v1beta1.ClusterServiceClass{})
 	if obj == nil {

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_clusterserviceplan.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_clusterserviceplan.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeClusterServicePlans implements ClusterServicePlanInterface
-type FakeClusterServicePlans struct {
-	Fake *FakeServicecatalogV1beta1
+// ClusterServicePlans implements ClusterServicePlanInterface
+type ClusterServicePlans struct {
+	Fake *ServicecatalogV1beta1
 }
 
 var clusterserviceplansResource = schema.GroupVersionResource{Group: "servicecatalog.k8s.io", Version: "v1beta1", Resource: "clusterserviceplans"}
@@ -36,7 +36,7 @@ var clusterserviceplansResource = schema.GroupVersionResource{Group: "servicecat
 var clusterserviceplansKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "v1beta1", Kind: "ClusterServicePlan"}
 
 // Get takes name of the clusterServicePlan, and returns the corresponding clusterServicePlan object, and an error if there is any.
-func (c *FakeClusterServicePlans) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterServicePlan, err error) {
+func (c *ClusterServicePlans) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterServicePlan, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterserviceplansResource, name), &v1beta1.ClusterServicePlan{})
 	if obj == nil {
@@ -46,7 +46,7 @@ func (c *FakeClusterServicePlans) Get(name string, options v1.GetOptions) (resul
 }
 
 // List takes label and field selectors, and returns the list of ClusterServicePlans that match those selectors.
-func (c *FakeClusterServicePlans) List(opts v1.ListOptions) (result *v1beta1.ClusterServicePlanList, err error) {
+func (c *ClusterServicePlans) List(opts v1.ListOptions) (result *v1beta1.ClusterServicePlanList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterserviceplansResource, clusterserviceplansKind, opts), &v1beta1.ClusterServicePlanList{})
 	if obj == nil {
@@ -67,13 +67,13 @@ func (c *FakeClusterServicePlans) List(opts v1.ListOptions) (result *v1beta1.Clu
 }
 
 // Watch returns a watch.Interface that watches the requested clusterServicePlans.
-func (c *FakeClusterServicePlans) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ClusterServicePlans) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterserviceplansResource, opts))
 }
 
 // Create takes the representation of a clusterServicePlan and creates it.  Returns the server's representation of the clusterServicePlan, and an error, if there is any.
-func (c *FakeClusterServicePlans) Create(clusterServicePlan *v1beta1.ClusterServicePlan) (result *v1beta1.ClusterServicePlan, err error) {
+func (c *ClusterServicePlans) Create(clusterServicePlan *v1beta1.ClusterServicePlan) (result *v1beta1.ClusterServicePlan, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterserviceplansResource, clusterServicePlan), &v1beta1.ClusterServicePlan{})
 	if obj == nil {
@@ -83,7 +83,7 @@ func (c *FakeClusterServicePlans) Create(clusterServicePlan *v1beta1.ClusterServ
 }
 
 // Update takes the representation of a clusterServicePlan and updates it. Returns the server's representation of the clusterServicePlan, and an error, if there is any.
-func (c *FakeClusterServicePlans) Update(clusterServicePlan *v1beta1.ClusterServicePlan) (result *v1beta1.ClusterServicePlan, err error) {
+func (c *ClusterServicePlans) Update(clusterServicePlan *v1beta1.ClusterServicePlan) (result *v1beta1.ClusterServicePlan, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterserviceplansResource, clusterServicePlan), &v1beta1.ClusterServicePlan{})
 	if obj == nil {
@@ -94,7 +94,7 @@ func (c *FakeClusterServicePlans) Update(clusterServicePlan *v1beta1.ClusterServ
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeClusterServicePlans) UpdateStatus(clusterServicePlan *v1beta1.ClusterServicePlan) (*v1beta1.ClusterServicePlan, error) {
+func (c *ClusterServicePlans) UpdateStatus(clusterServicePlan *v1beta1.ClusterServicePlan) (*v1beta1.ClusterServicePlan, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(clusterserviceplansResource, "status", clusterServicePlan), &v1beta1.ClusterServicePlan{})
 	if obj == nil {
@@ -104,14 +104,14 @@ func (c *FakeClusterServicePlans) UpdateStatus(clusterServicePlan *v1beta1.Clust
 }
 
 // Delete takes name of the clusterServicePlan and deletes it. Returns an error if one occurs.
-func (c *FakeClusterServicePlans) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ClusterServicePlans) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterserviceplansResource, name), &v1beta1.ClusterServicePlan{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeClusterServicePlans) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ClusterServicePlans) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterserviceplansResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ClusterServicePlanList{})
@@ -119,7 +119,7 @@ func (c *FakeClusterServicePlans) DeleteCollection(options *v1.DeleteOptions, li
 }
 
 // Patch applies the patch and returns the patched clusterServicePlan.
-func (c *FakeClusterServicePlans) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ClusterServicePlan, err error) {
+func (c *ClusterServicePlans) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ClusterServicePlan, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootPatchSubresourceAction(clusterserviceplansResource, name, data, subresources...), &v1beta1.ClusterServicePlan{})
 	if obj == nil {

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_servicebinding.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_servicebinding.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeServiceBindings implements ServiceBindingInterface
-type FakeServiceBindings struct {
-	Fake *FakeServicecatalogV1beta1
+// ServiceBindings implements ServiceBindingInterface
+type ServiceBindings struct {
+	Fake *ServicecatalogV1beta1
 	ns   string
 }
 
@@ -37,7 +37,7 @@ var servicebindingsResource = schema.GroupVersionResource{Group: "servicecatalog
 var servicebindingsKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "v1beta1", Kind: "ServiceBinding"}
 
 // Get takes name of the serviceBinding, and returns the corresponding serviceBinding object, and an error if there is any.
-func (c *FakeServiceBindings) Get(name string, options v1.GetOptions) (result *v1beta1.ServiceBinding, err error) {
+func (c *ServiceBindings) Get(name string, options v1.GetOptions) (result *v1beta1.ServiceBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(servicebindingsResource, c.ns, name), &v1beta1.ServiceBinding{})
 
@@ -48,7 +48,7 @@ func (c *FakeServiceBindings) Get(name string, options v1.GetOptions) (result *v
 }
 
 // List takes label and field selectors, and returns the list of ServiceBindings that match those selectors.
-func (c *FakeServiceBindings) List(opts v1.ListOptions) (result *v1beta1.ServiceBindingList, err error) {
+func (c *ServiceBindings) List(opts v1.ListOptions) (result *v1beta1.ServiceBindingList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(servicebindingsResource, servicebindingsKind, c.ns, opts), &v1beta1.ServiceBindingList{})
 
@@ -70,14 +70,14 @@ func (c *FakeServiceBindings) List(opts v1.ListOptions) (result *v1beta1.Service
 }
 
 // Watch returns a watch.Interface that watches the requested serviceBindings.
-func (c *FakeServiceBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ServiceBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(servicebindingsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a serviceBinding and creates it.  Returns the server's representation of the serviceBinding, and an error, if there is any.
-func (c *FakeServiceBindings) Create(serviceBinding *v1beta1.ServiceBinding) (result *v1beta1.ServiceBinding, err error) {
+func (c *ServiceBindings) Create(serviceBinding *v1beta1.ServiceBinding) (result *v1beta1.ServiceBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(servicebindingsResource, c.ns, serviceBinding), &v1beta1.ServiceBinding{})
 
@@ -88,7 +88,7 @@ func (c *FakeServiceBindings) Create(serviceBinding *v1beta1.ServiceBinding) (re
 }
 
 // Update takes the representation of a serviceBinding and updates it. Returns the server's representation of the serviceBinding, and an error, if there is any.
-func (c *FakeServiceBindings) Update(serviceBinding *v1beta1.ServiceBinding) (result *v1beta1.ServiceBinding, err error) {
+func (c *ServiceBindings) Update(serviceBinding *v1beta1.ServiceBinding) (result *v1beta1.ServiceBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(servicebindingsResource, c.ns, serviceBinding), &v1beta1.ServiceBinding{})
 
@@ -100,7 +100,7 @@ func (c *FakeServiceBindings) Update(serviceBinding *v1beta1.ServiceBinding) (re
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeServiceBindings) UpdateStatus(serviceBinding *v1beta1.ServiceBinding) (*v1beta1.ServiceBinding, error) {
+func (c *ServiceBindings) UpdateStatus(serviceBinding *v1beta1.ServiceBinding) (*v1beta1.ServiceBinding, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(servicebindingsResource, "status", c.ns, serviceBinding), &v1beta1.ServiceBinding{})
 
@@ -111,7 +111,7 @@ func (c *FakeServiceBindings) UpdateStatus(serviceBinding *v1beta1.ServiceBindin
 }
 
 // Delete takes name of the serviceBinding and deletes it. Returns an error if one occurs.
-func (c *FakeServiceBindings) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ServiceBindings) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(servicebindingsResource, c.ns, name), &v1beta1.ServiceBinding{})
 
@@ -119,7 +119,7 @@ func (c *FakeServiceBindings) Delete(name string, options *v1.DeleteOptions) err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeServiceBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ServiceBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(servicebindingsResource, c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ServiceBindingList{})
@@ -127,7 +127,7 @@ func (c *FakeServiceBindings) DeleteCollection(options *v1.DeleteOptions, listOp
 }
 
 // Patch applies the patch and returns the patched serviceBinding.
-func (c *FakeServiceBindings) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ServiceBinding, err error) {
+func (c *ServiceBindings) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ServiceBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(servicebindingsResource, c.ns, name, data, subresources...), &v1beta1.ServiceBinding{})
 

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_servicecatalog_client.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_servicecatalog_client.go
@@ -17,38 +17,38 @@ limitations under the License.
 package fake
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1"
-	rest "k8s.io/client-go/rest"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/testing"
 )
 
-type FakeServicecatalogV1beta1 struct {
+type ServicecatalogV1beta1 struct {
 	*testing.Fake
 }
 
-func (c *FakeServicecatalogV1beta1) ClusterServiceBrokers() v1beta1.ClusterServiceBrokerInterface {
-	return &FakeClusterServiceBrokers{c}
+func (c *ServicecatalogV1beta1) ClusterServiceBrokers() v1beta1.ClusterServiceBrokerInterface {
+	return &ClusterServiceBrokers{c}
 }
 
-func (c *FakeServicecatalogV1beta1) ClusterServiceClasses() v1beta1.ClusterServiceClassInterface {
-	return &FakeClusterServiceClasses{c}
+func (c *ServicecatalogV1beta1) ClusterServiceClasses() v1beta1.ClusterServiceClassInterface {
+	return &ClusterServiceClasses{c}
 }
 
-func (c *FakeServicecatalogV1beta1) ClusterServicePlans() v1beta1.ClusterServicePlanInterface {
-	return &FakeClusterServicePlans{c}
+func (c *ServicecatalogV1beta1) ClusterServicePlans() v1beta1.ClusterServicePlanInterface {
+	return &ClusterServicePlans{c}
 }
 
-func (c *FakeServicecatalogV1beta1) ServiceBindings(namespace string) v1beta1.ServiceBindingInterface {
-	return &FakeServiceBindings{c, namespace}
+func (c *ServicecatalogV1beta1) ServiceBindings(namespace string) v1beta1.ServiceBindingInterface {
+	return &ServiceBindings{c, namespace}
 }
 
-func (c *FakeServicecatalogV1beta1) ServiceInstances(namespace string) v1beta1.ServiceInstanceInterface {
-	return &FakeServiceInstances{c, namespace}
+func (c *ServicecatalogV1beta1) ServiceInstances(namespace string) v1beta1.ServiceInstanceInterface {
+	return &ServiceInstances{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeServicecatalogV1beta1) RESTClient() rest.Interface {
+func (c *ServicecatalogV1beta1) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_serviceinstance.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/fake/fake_serviceinstance.go
@@ -17,18 +17,18 @@ limitations under the License.
 package fake
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
 )
 
-// FakeServiceInstances implements ServiceInstanceInterface
-type FakeServiceInstances struct {
-	Fake *FakeServicecatalogV1beta1
+// ServiceInstances implements ServiceInstanceInterface
+type ServiceInstances struct {
+	Fake *ServicecatalogV1beta1
 	ns   string
 }
 
@@ -37,7 +37,7 @@ var serviceinstancesResource = schema.GroupVersionResource{Group: "servicecatalo
 var serviceinstancesKind = schema.GroupVersionKind{Group: "servicecatalog.k8s.io", Version: "v1beta1", Kind: "ServiceInstance"}
 
 // Get takes name of the serviceInstance, and returns the corresponding serviceInstance object, and an error if there is any.
-func (c *FakeServiceInstances) Get(name string, options v1.GetOptions) (result *v1beta1.ServiceInstance, err error) {
+func (c *ServiceInstances) Get(name string, options v1.GetOptions) (result *v1beta1.ServiceInstance, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(serviceinstancesResource, c.ns, name), &v1beta1.ServiceInstance{})
 
@@ -48,7 +48,7 @@ func (c *FakeServiceInstances) Get(name string, options v1.GetOptions) (result *
 }
 
 // List takes label and field selectors, and returns the list of ServiceInstances that match those selectors.
-func (c *FakeServiceInstances) List(opts v1.ListOptions) (result *v1beta1.ServiceInstanceList, err error) {
+func (c *ServiceInstances) List(opts v1.ListOptions) (result *v1beta1.ServiceInstanceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(serviceinstancesResource, serviceinstancesKind, c.ns, opts), &v1beta1.ServiceInstanceList{})
 
@@ -70,14 +70,14 @@ func (c *FakeServiceInstances) List(opts v1.ListOptions) (result *v1beta1.Servic
 }
 
 // Watch returns a watch.Interface that watches the requested serviceInstances.
-func (c *FakeServiceInstances) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *ServiceInstances) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(serviceinstancesResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a serviceInstance and creates it.  Returns the server's representation of the serviceInstance, and an error, if there is any.
-func (c *FakeServiceInstances) Create(serviceInstance *v1beta1.ServiceInstance) (result *v1beta1.ServiceInstance, err error) {
+func (c *ServiceInstances) Create(serviceInstance *v1beta1.ServiceInstance) (result *v1beta1.ServiceInstance, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(serviceinstancesResource, c.ns, serviceInstance), &v1beta1.ServiceInstance{})
 
@@ -88,7 +88,7 @@ func (c *FakeServiceInstances) Create(serviceInstance *v1beta1.ServiceInstance) 
 }
 
 // Update takes the representation of a serviceInstance and updates it. Returns the server's representation of the serviceInstance, and an error, if there is any.
-func (c *FakeServiceInstances) Update(serviceInstance *v1beta1.ServiceInstance) (result *v1beta1.ServiceInstance, err error) {
+func (c *ServiceInstances) Update(serviceInstance *v1beta1.ServiceInstance) (result *v1beta1.ServiceInstance, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(serviceinstancesResource, c.ns, serviceInstance), &v1beta1.ServiceInstance{})
 
@@ -100,7 +100,7 @@ func (c *FakeServiceInstances) Update(serviceInstance *v1beta1.ServiceInstance) 
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeServiceInstances) UpdateStatus(serviceInstance *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, error) {
+func (c *ServiceInstances) UpdateStatus(serviceInstance *v1beta1.ServiceInstance) (*v1beta1.ServiceInstance, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(serviceinstancesResource, "status", c.ns, serviceInstance), &v1beta1.ServiceInstance{})
 
@@ -111,7 +111,7 @@ func (c *FakeServiceInstances) UpdateStatus(serviceInstance *v1beta1.ServiceInst
 }
 
 // Delete takes name of the serviceInstance and deletes it. Returns an error if one occurs.
-func (c *FakeServiceInstances) Delete(name string, options *v1.DeleteOptions) error {
+func (c *ServiceInstances) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(serviceinstancesResource, c.ns, name), &v1beta1.ServiceInstance{})
 
@@ -119,7 +119,7 @@ func (c *FakeServiceInstances) Delete(name string, options *v1.DeleteOptions) er
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeServiceInstances) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+func (c *ServiceInstances) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(serviceinstancesResource, c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ServiceInstanceList{})
@@ -127,7 +127,7 @@ func (c *FakeServiceInstances) DeleteCollection(options *v1.DeleteOptions, listO
 }
 
 // Patch applies the patch and returns the patched serviceInstance.
-func (c *FakeServiceInstances) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ServiceInstance, err error) {
+func (c *ServiceInstances) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ServiceInstance, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(serviceinstancesResource, c.ns, name, data, subresources...), &v1beta1.ServiceInstance{})
 

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/servicebinding.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/servicebinding.go
@@ -17,12 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ServiceBindingsGetter has a method to return a ServiceBindingInterface.

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/servicecatalog_client.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/servicecatalog_client.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
 	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	rest "k8s.io/client-go/rest"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
 )
 
 type ServicecatalogV1beta1Interface interface {

--- a/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/serviceinstance.go
+++ b/pkg/client/servicecatalog/clientset/versioned/typed/servicecatalog/v1beta1/serviceinstance.go
@@ -17,12 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
-	scheme "github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
+	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 )
 
 // ServiceInstancesGetter has a method to return a ServiceInstanceInterface.

--- a/pkg/cmd/clientConfig.go
+++ b/pkg/cmd/clientConfig.go
@@ -62,7 +62,7 @@ kubectl plugin mobile get clientconfig`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var ns string
 			var err error
-			ret := []*ServiceConfig{}
+			ret := make([]*ServiceConfig, 0)
 			convertors := map[string]SecretConvertor{
 				"fh-sync-server": &syncSecretConvertor{},
 				"keycloak":       &keycloakSecretConvertor{},

--- a/pkg/cmd/clientConfig_test.go
+++ b/pkg/cmd/clientConfig_test.go
@@ -38,7 +38,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 func TestClientConfigCmd_GetClientConfigCmd(t *testing.T) {

--- a/pkg/cmd/clients.go
+++ b/pkg/cmd/clients.go
@@ -25,7 +25,7 @@ import (
 	"github.com/aerogear/mobile-cli/pkg/cmd/output"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/cmd/clients_test.go
+++ b/pkg/cmd/clients_test.go
@@ -125,15 +125,15 @@ func TestMobileClientsCmd_TestGetClient(t *testing.T) {
 		{
 			Name: "test get client returns only one client with the right name",
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("get", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
+				fkMc := &mcFake.Clientset{}
+				fkMc.AddReactor("get", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
 					return true, &v1alpha1.MobileClient{
 						Spec: v1alpha1.MobileClientSpec{
 							Name: "myapp",
 						},
 					}, nil
 				})
-				return mc
+				return fkMc
 			},
 			ClientName:  "myapp",
 			ExpectError: false,
@@ -150,11 +150,11 @@ func TestMobileClientsCmd_TestGetClient(t *testing.T) {
 		{
 			Name: "test get client returns a clear error when it fails",
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("get", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
+				fkMc := &mcFake.Clientset{}
+				fkMc.AddReactor("get", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("failed to get mobile client")
 				})
-				return mc
+				return fkMc
 			},
 			ClientName:   "myapp",
 			Flags:        []string{"--namespace=myproject", "-o=json"},
@@ -164,8 +164,8 @@ func TestMobileClientsCmd_TestGetClient(t *testing.T) {
 		{
 			Name: "test get client fails and returns usage when missing a required argument",
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				return mc
+				fkMc := &mcFake.Clientset{}
+				return fkMc
 			},
 			ClientName:  "",
 			Flags:       []string{"--namespace=myproject", "-o=json"},
@@ -228,8 +228,8 @@ func TestMobileClientsCmd_TestDeleteClient(t *testing.T) {
 		{
 			Name: "test delete client succeeds with no errors",
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				return mc
+				fkMc := &mcFake.Clientset{}
+				return fkMc
 			},
 			ClientName: "myapp",
 			Flags:      []string{"--namespace=myproject", "-o=json"},
@@ -237,8 +237,8 @@ func TestMobileClientsCmd_TestDeleteClient(t *testing.T) {
 		{
 			Name: "test delete client fails and returns usage when missing arguments",
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				return mc
+				fkMc := &mcFake.Clientset{}
+				return fkMc
 			},
 			Flags:       []string{"--namespace=myproject", "-o=json"},
 			ExpectError: false,
@@ -247,11 +247,11 @@ func TestMobileClientsCmd_TestDeleteClient(t *testing.T) {
 		{
 			Name: "test delete client returns a clear error when delete fails",
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("delete", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
+				fkMc := &mcFake.Clientset{}
+				fkMc.AddReactor("delete", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("failed to delete mobileclient")
 				})
-				return mc
+				return fkMc
 			},
 			ExpectUsage: true,
 			Flags:       []string{"--namespace=myproject", "-o=json"},
@@ -310,12 +310,12 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 			Name: "test create cordova mobile client succeeds without error",
 			Args: []string{"test", "cordova", "my.app.org"},
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
+				fkMc := &mcFake.Clientset{}
+				fkMc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
 					ca := action.(kt.CreateAction)
 					return true, ca.GetObject(), nil
 				})
-				return mc
+				return fkMc
 			},
 			Flags: []string{"--namespace=myproject", "-o=json"},
 			Validate: func(t *testing.T, c *v1alpha1.MobileClient) {
@@ -347,12 +347,12 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 			Name: "test create android mobile client succeeds without error",
 			Args: []string{"test", "android", "my.app.org"},
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
+				fkMc := &mcFake.Clientset{}
+				fkMc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
 					ca := action.(kt.CreateAction)
 					return true, ca.GetObject(), nil
 				})
-				return mc
+				return fkMc
 			},
 			Flags: []string{"--namespace=myproject", "-o=json"},
 			Validate: func(t *testing.T, c *v1alpha1.MobileClient) {
@@ -384,12 +384,12 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 			Name: "test create iOS mobile client succeeds without error",
 			Args: []string{"test", "iOS", "my.app.org"},
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
+				fkMc := &mcFake.Clientset{}
+				fkMc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
 					ca := action.(kt.CreateAction)
 					return true, ca.GetObject(), nil
 				})
-				return mc
+				return fkMc
 			},
 			Flags: []string{"--namespace=myproject", "-o=json"},
 			Validate: func(t *testing.T, c *v1alpha1.MobileClient) {
@@ -423,11 +423,11 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 			ExpectError:  true,
 			ErrorPattern: "^Failed validation while creating new mobile client: .*",
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
+				fkMc := &mcFake.Clientset{}
+				fkMc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("should not have been called")
 				})
-				return mc
+				return fkMc
 			},
 			Flags: []string{"--namespace=myproject", "-o=json"},
 		},
@@ -437,8 +437,8 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 			ExpectError: false,
 			ExpectUsage: true,
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				return mc
+				fkMc := &mcFake.Clientset{}
+				return fkMc
 			},
 			Flags: []string{"--namespace=myproject", "-o=json"},
 		},
@@ -448,11 +448,11 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 			ExpectError:  true,
 			ErrorPattern: "^failed to create mobile client: something went wrong",
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
+				fkMc := &mcFake.Clientset{}
+				fkMc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("something went wrong")
 				})
-				return mc
+				return fkMc
 			},
 			Flags: []string{"--namespace=myproject", "-o=json"},
 		},
@@ -462,11 +462,11 @@ func TestMobileClientsCmd_TestCreateClient(t *testing.T) {
 			ExpectError:  true,
 			ErrorPattern: "^Failed validation while creating new mobile client: .*",
 			MobileClient: func() mc.Interface {
-				mc := &mcFake.Clientset{}
-				mc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
+				fkMc := &mcFake.Clientset{}
+				fkMc.AddReactor("create", "mobileclients", func(action kt.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, errors.New("should not have been called")
 				})
-				return mc
+				return fkMc
 			},
 			Flags: []string{"--namespace=myproject", "-o=json"},
 		},

--- a/pkg/cmd/convert.go
+++ b/pkg/cmd/convert.go
@@ -17,7 +17,7 @@ package cmd
 import (
 	"strings"
 
-	v1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 func isClientConfigKey(key string) bool {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -55,7 +55,7 @@ func mustGetStrFlag(flags *pflag.FlagSet, name string) string {
 		log.Fatal("failed to get flag "+name, err)
 	}
 	if val == "" {
-		log.Fatal("missing required flag argument " + name + "\n")
+		log.Fatalln("missing required flag argument " + name)
 	}
 	return val
 }

--- a/pkg/cmd/serviceConfig.go
+++ b/pkg/cmd/serviceConfig.go
@@ -29,23 +29,23 @@ import (
 // TODO move to the secret data read when discovering the services
 //TODO need to come up with a better way of representing this
 var capabilities = map[string]map[string][]string{
-	"fh-sync-server": map[string][]string{
+	"fh-sync-server": {
 		"capabilities": {"data storage, data syncronisation"},
 		"integrations": {ServiceNameKeycloak, IntegrationAPIKeys, ServiceNameThreeScale},
 	},
-	"keycloak": map[string][]string{
+	"keycloak": {
 		"capabilities": {"authentication, authorisation"},
 		"integrations": {},
 	},
-	"mcp-mobile-keys": map[string][]string{
+	"mcp-mobile-keys": {
 		"capabilities": {"access apps"},
 		"integrations": {},
 	},
-	"3scale": map[string][]string{
+	"3scale": {
 		"capabilities": {"authentication, authorization"},
 		"integrations": {},
 	},
-	"custom": map[string][]string{
+	"custom": {
 		"capabilities": {""},
 		"integrations": {""},
 	},
@@ -56,7 +56,7 @@ func listServices(ns string, k8Client kubernetes.Interface) []*Service {
 	if err != nil {
 		log.Fatal("failed to get mobile services. Backing secrets error ", err)
 	}
-	out := []*Service{}
+	var out []*Service
 	for _, s := range secrets.Items {
 		out = append(out, convertSecretToMobileService(s))
 	}

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -16,15 +16,9 @@ package cmd
 
 import (
 	"encoding/json"
-
-	"net/http"
-
-	"io"
-
 	"github.com/pkg/errors"
+	"net/http"
 )
-
-var renderers = map[string]func(writer io.Writer, data interface{}) error{}
 
 //Service represents a serverside application that mobile application will interact with
 type Service struct {


### PR DESCRIPTION
Redundant import aliases that can be omitted
Redundant type declaration in composite literals
Type can be omitted
Unused global variables
Unused import
Name starts with package name
Rename public function
Imported package name as name identifier