### PR TITLE
Filter client config on service labels

### DIFF
--- a/pkg/cmd/clientConfig.go
+++ b/pkg/cmd/clientConfig.go
@@ -117,9 +117,6 @@ kubectl plugin mobile get clientconfig`,
 	ccc.Out.AddRenderer("get"+cmd.Name(), "table", func(writer io.Writer, serviceConfigs interface{}) error {
 		serviceConfigList := serviceConfigs.(ServiceConfigs)
 		var data [][]string
-		if serviceConfigList.ClientID != "" {
-			data = append(data, []string{"Client ID", serviceConfigList.ClientID, "", ""})
-		}
 		for _, service := range serviceConfigList.Services {
 			data = append(data, []string{service.ID, service.Name, service.Type, service.URL})
 		}

--- a/pkg/cmd/clientConfig_test.go
+++ b/pkg/cmd/clientConfig_test.go
@@ -130,7 +130,8 @@ func TestClientConfigCmd_GetClientConfigCmd(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "test-service",
 								Labels: map[string]string{
-									"mobile": "enabled",
+									"mobile":   "enabled",
+									"clientId": "client-id",
 								},
 							},
 							Data: map[string][]byte{
@@ -141,7 +142,8 @@ func TestClientConfigCmd_GetClientConfigCmd(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "keycloak",
 								Labels: map[string]string{
-									"mobile": "enabled",
+									"mobile":   "enabled",
+									"clientId": "client-id",
 								},
 							},
 							Data: map[string][]byte{
@@ -153,26 +155,6 @@ func TestClientConfigCmd_GetClientConfigCmd(t *testing.T) {
 						Items: secrets,
 					}
 					return true, secretList, nil
-				})
-				fakeclient.AddReactor("get", "configmaps", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-					var config *v1.ConfigMap
-					name := action.(ktesting.GetAction).GetName()
-					if name == "keycloak" {
-						config = &v1.ConfigMap{
-							Data: map[string]string{
-								"public_installation": "{}",
-								"name":                "keycloak",
-							},
-						}
-					}
-					if name == "test-service" {
-						config = &v1.ConfigMap{
-							Data: map[string]string{
-								"name": "test-service",
-							},
-						}
-					}
-					return true, config, nil
 				})
 				return fakeclient
 			},


### PR DESCRIPTION
This change relates to [AEROGEAR-2419](https://issues.jboss.org/browse/AEROGEAR-2419).

Because bindings use secrets by default, our APB's have followed this format and standardised on the `ServiceConfig` object based on [this proposal](https://github.com/aerogear/proposals/blob/master/sdks/Mobile-configuration.md#service-object)

Going forward, all mobile APB secrets created via a binding will have the label `clientId` applied to them

Changes proposed in this pull request
 - Search for related secrets in the `get clientconfig` command, filtering on `mobileClientId` label
 - Remove redundant code used to convert ConfigMaps to specific ServiceConfig objects since the linked proposal invalidates these formats

#### Verification Steps
1. Build and push https://github.com/aerogearcatalog/custom-runtime-connector-apb
1. Create a Cordova, iOS and Android client app
1. Bind each mobile app to crc
1. Run mobile-cli binary with args `get clientconfig <my-app-name> -o json` and ensure expected config output for all client types