### PR TITLE
Add xamarin to the client type pattern within the mobile crd definition

### DIFF
--- a/artifacts/mobileclient_crd.yaml
+++ b/artifacts/mobileclient_crd.yaml
@@ -20,7 +20,7 @@ spec:
           properties:
             clientType:
               type: string
-              pattern: 'cordova|iOS|android'
+              pattern: 'cordova|iOS|android|xamarin'
             apiKey:
               type: string
               pattern: '(\w{8}-\w{4}-\w{4}-\w{4}-\w{11})'


### PR DESCRIPTION
## Description
`xamarin` needs to be added to the client type pattern within the mobile client crd definition in order to allow for xamarin support.

**Fixes issue:** 
```
Error: failed to create mobile client: MobileClient.mobile.k8s.io "test-xamarin" is invalid: []: Invalid value: map[string]interface {}{"kind":"MobileClient", "apiVersion":"mobile.k8s.io/v1alpha1", "metadata":map[string]interface {}{"name":"test-xamarin", "creationTimestamp":"2018-04-23T14:28:19Z", "annotations":map[string]interface {}{"icon":"font-icon icon-xamarin"}, "namespace":"test5", "uid":"91bae668-4702-11e8-b28b-72846aeed9ee", "selfLink":"", "clusterName":""}, "spec":map[string]interface {}{"name":"test", "apiKey":"6a5ff4d6-34de-4df5-b14b-9b533fd8b95f", "clientType":"xamarin", "appIdentifier":"test-package-name"}}: validation failure list:
spec.clientType in body should match 'cordova|iOS|android'