### PR TITLE
[AEROGEAR-2598] Update CLI to work with the latest APB changes

### DIFF
--- a/pkg/cmd/integration_test.go
+++ b/pkg/cmd/integration_test.go
@@ -1,10 +1,10 @@
 package cmd_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"testing"
-
-	"bytes"
 
 	"github.com/aerogear/mobile-cli/pkg/apis/servicecatalog/v1beta1"
 	"github.com/aerogear/mobile-cli/pkg/client/servicecatalog/clientset/versioned"
@@ -117,6 +117,34 @@ func TestIntegrationCmd_CreateIntegrationCmd(t *testing.T) {
 				fake.AddReactor("get", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, &v1beta1.ClusterServiceClass{Spec: v1beta1.ClusterServiceClassSpec{ExternalMetadata: &runtime.RawExtension{Raw: []byte(`{"serviceName":"test"}`)}}}, nil
 				})
+				fake.AddReactor("list", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					externalData := cmd.ExternalServiceMetaData{
+						ServiceName: "test",
+					}
+					data, _ := json.Marshal(externalData)
+					return true, &v1beta1.ClusterServiceClassList{Items: []v1beta1.ClusterServiceClass{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test",
+							},
+							Spec: v1beta1.ClusterServiceClassSpec{
+								ExternalMetadata: &runtime.RawExtension{Raw: data},
+							},
+						},
+					}}, nil
+				})
+				fake.AddReactor("list", "clusterserviceplans", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					params := &cmd.ServiceParams{Required: []string{"CLIENT_NAME"}, Properties: map[string]map[string]interface{}{"CLIENT_NAME": {"value": "", "default": "test-client-name"}}}
+					b, _ := json.Marshal(params)
+					return true, &v1beta1.ClusterServicePlanList{Items: []v1beta1.ClusterServicePlan{
+						{Spec: v1beta1.ClusterServicePlanSpec{
+							ServiceBindingCreateParameterSchema: &runtime.RawExtension{Raw: b},
+							ClusterServiceClassRef:              v1beta1.ClusterObjectReference{Name: "test"},
+							ExternalName:                        "default"},
+						},
+					},
+					}, nil
+				})
 				return fake, fakeWatch, []runtime.Object{
 					defaultServiceBinding,
 				}
@@ -162,6 +190,34 @@ func TestIntegrationCmd_CreateIntegrationCmd(t *testing.T) {
 				})
 				fake.AddReactor("get", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, &v1beta1.ClusterServiceClass{Spec: v1beta1.ClusterServiceClassSpec{ExternalMetadata: &runtime.RawExtension{Raw: []byte(`{"serviceName":"test"}`)}}}, nil
+				})
+				fake.AddReactor("list", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					externalData := cmd.ExternalServiceMetaData{
+						ServiceName: "test",
+					}
+					data, _ := json.Marshal(externalData)
+					return true, &v1beta1.ClusterServiceClassList{Items: []v1beta1.ClusterServiceClass{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test",
+							},
+							Spec: v1beta1.ClusterServiceClassSpec{
+								ExternalMetadata: &runtime.RawExtension{Raw: data},
+							},
+						},
+					}}, nil
+				})
+				fake.AddReactor("list", "clusterserviceplans", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					params := &cmd.ServiceParams{Required: []string{"CLIENT_NAME"}, Properties: map[string]map[string]interface{}{"CLIENT_NAME": {"value": "", "default": "test-client-name"}}}
+					b, _ := json.Marshal(params)
+					return true, &v1beta1.ClusterServicePlanList{Items: []v1beta1.ClusterServicePlan{{
+						Spec: v1beta1.ClusterServicePlanSpec{
+							ServiceBindingCreateParameterSchema: &runtime.RawExtension{Raw: b},
+							ClusterServiceClassRef:              v1beta1.ClusterObjectReference{Name: "test"},
+							ExternalName:                        "default"},
+					},
+					},
+					}, nil
 				})
 				return fake, fakeWatch, []runtime.Object{
 					defaultServiceBinding,
@@ -234,6 +290,34 @@ func TestIntegrationCmd_CreateIntegrationCmd(t *testing.T) {
 				fake.AddReactor("get", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, &v1beta1.ClusterServiceClass{Spec: v1beta1.ClusterServiceClassSpec{ExternalMetadata: &runtime.RawExtension{Raw: []byte(`{"serviceName":"test"}`)}}}, nil
 				})
+				fake.AddReactor("list", "clusterserviceclasses", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					externalData := cmd.ExternalServiceMetaData{
+						ServiceName: "test",
+					}
+					data, _ := json.Marshal(externalData)
+					return true, &v1beta1.ClusterServiceClassList{Items: []v1beta1.ClusterServiceClass{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test",
+							},
+							Spec: v1beta1.ClusterServiceClassSpec{
+								ExternalMetadata: &runtime.RawExtension{Raw: data},
+							},
+						},
+					}}, nil
+				})
+				fake.AddReactor("list", "clusterserviceplans", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					params := &cmd.ServiceParams{Required: []string{"CLIENT_NAME"}, Properties: map[string]map[string]interface{}{"CLIENT_NAME": {"value": "", "default": "test-client-name"}}}
+					b, _ := json.Marshal(params)
+					return true, &v1beta1.ClusterServicePlanList{Items: []v1beta1.ClusterServicePlan{{
+						Spec: v1beta1.ClusterServicePlanSpec{
+							ServiceBindingCreateParameterSchema: &runtime.RawExtension{Raw: b},
+							ClusterServiceClassRef:              v1beta1.ClusterObjectReference{Name: "test"},
+							ExternalName:                        "default"},
+					},
+					},
+					}, nil
+				})
 				return fake, fakeWatch, []runtime.Object{
 					defaultServiceBinding,
 				}
@@ -254,7 +338,7 @@ func TestIntegrationCmd_CreateIntegrationCmd(t *testing.T) {
 				return fake
 			},
 			Args:  []string{"keycloak", "fh-sync-server"},
-			Flags: []string{"--namespace=test", "--auto-redeploy=true", "--no-wait=true"},
+			Flags: []string{"--namespace=test", "-pCLIENT_NAME=test", "--auto-redeploy=true", "--no-wait=true"},
 		},
 	}
 

--- a/pkg/cmd/params.go
+++ b/pkg/cmd/params.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ServiceParams for creating integration and binding
+type ServiceParams struct {
+	AdditionalProperties bool                              `json:"additionalProperties"`
+	Properties           map[string]map[string]interface{} `json:"properties"`
+	Required             []string                          `json:"required"`
+	Type                 string                            `json:"type"`
+}
+
+func parseParams(keyVals []string) (map[string]string, error) {
+	params := map[string]string{}
+	for _, p := range keyVals {
+		kv := strings.Split(p, "=")
+		if len(kv) != 2 {
+			return nil, NewIncorrectParameterFormat("key value pairs are needed failed to find one: " + p)
+		}
+		params[strings.TrimSpace(kv[0])] = kv[1]
+	}
+	return params, nil
+}
+
+func isRequired(params ServiceParams, key string) bool {
+	for _, r := range params.Required {
+		if r == key {
+			return true
+		}
+	}
+	return false
+}
+
+// GetParams - Gets the service parameters (i.e. for provision/bind service) from the params
+//             flag or as a user input
+func GetParams(flagParams []string, params *ServiceParams) (*ServiceParams, error) {
+	parsedParams, err := parseParams(flagParams)
+	if err != nil {
+		return params, errors.WithStack(err)
+	}
+
+	if len(parsedParams) > 0 {
+		for k, v := range params.Properties {
+			defaultVal := v["default"]
+			if pVal, ok := parsedParams[k]; !ok && isRequired(*params, k) || isRequired(*params, k) && pVal == "" {
+				if defaultVal != nil {
+					//use default
+					v["value"] = defaultVal
+					continue
+				}
+				return params, errors.New(fmt.Sprintf("missing required parameter %s", k))
+			}
+			v["value"] = parsedParams[k]
+			params.Properties[k] = v
+		}
+	} else {
+		scanner := bufio.NewScanner(os.Stdin)
+		for k, v := range params.Properties {
+			validInput := false
+			val := ""
+			for validInput == false {
+				questionFormat := "Set value for %s [default value: %s, required: %v]"
+				if v["default"] != nil {
+					fmt.Println(fmt.Sprintf(questionFormat, k, v["default"], isRequired(*params, k)))
+				} else {
+					fmt.Println(fmt.Sprintf(questionFormat, k, "<no default value>", isRequired(*params, k)))
+				}
+				scanner.Scan()
+
+				val = strings.TrimSpace(scanner.Text())
+
+				if len(val) > 0 {
+					validInput = true
+				}
+				if validInput == false && val == "" && v["default"] != nil {
+					val = v["default"].(string)
+					validInput = true
+				}
+				if validInput == false && val == "" && !isRequired(*params, k) {
+					validInput = true
+				}
+				if validInput == false {
+					fmt.Println("Invalid option for required field.")
+				}
+			}
+			v["value"] = val
+			params.Properties[k] = v
+			fmt.Println(fmt.Sprintf("Value for %s set to: %s", k, val))
+		}
+	}
+	return params, nil
+}

--- a/pkg/cmd/services_test.go
+++ b/pkg/cmd/services_test.go
@@ -373,7 +373,7 @@ func TestServicesCmd_CreateServiceInstanceCmd(t *testing.T) {
 					}}, nil
 				})
 				fakeClient.AddReactor("list", "clusterserviceplans", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-					params := &cmd.InstanceCreateParams{Required: []string{"ADMIN_NAME"}, Properties: map[string]map[string]interface{}{"ADMIN_NAME": {"value": ""}}}
+					params := &cmd.ServiceParams{Required: []string{"ADMIN_NAME"}, Properties: map[string]map[string]interface{}{"ADMIN_NAME": {"value": ""}}}
 					b, _ := json.Marshal(params)
 					return true, &v1beta1.ClusterServicePlanList{Items: []v1beta1.ClusterServicePlan{{
 						Spec: v1beta1.ClusterServicePlanSpec{ServiceInstanceCreateParameterSchema: &runtime.RawExtension{Raw: b}, ClusterServiceClassRef: v1beta1.ClusterObjectReference{Name: "test"}, ExternalName: "default"},
@@ -414,7 +414,7 @@ func TestServicesCmd_CreateServiceInstanceCmd(t *testing.T) {
 					}}, nil
 				})
 				fakeClient.AddReactor("list", "clusterserviceplans", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-					params := &cmd.InstanceCreateParams{Required: []string{"ADMIN_NAME"}, Properties: map[string]map[string]interface{}{"ADMIN_NAME": {"value": "", "default": "admin"}}}
+					params := &cmd.ServiceParams{Required: []string{"ADMIN_NAME"}, Properties: map[string]map[string]interface{}{"ADMIN_NAME": {"value": "", "default": "admin"}}}
 					b, _ := json.Marshal(params)
 					return true, &v1beta1.ClusterServicePlanList{Items: []v1beta1.ClusterServicePlan{{
 						Spec: v1beta1.ClusterServicePlanSpec{ServiceInstanceCreateParameterSchema: &runtime.RawExtension{Raw: b}, ClusterServiceClassRef: v1beta1.ClusterObjectReference{Name: "test"}, ExternalName: "default"},


### PR DESCRIPTION
## Description
Update the CLI to work with the latest APB changes (This includes the removal of labels from the service instance and additional parameters to the bind process for Keycloak). 

## Progress
- [x] Remove check for serviceName label in the provision watch as the labels for the mobile service has been removed.
- [x] Update the integration command to ask for the bind parameters similar to how they are asked during provision.
- [x] Update tests

## Additional Notes
Related JIRA Ticket - https://issues.jboss.org/browse/AEROGEAR-2598