### PR TITLE
[AEROGEAR-2639] Add CLI installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,18 @@ mobile get clientconfig <mobileClientID> --namespace=<namespace>
 mobile create integration <consumingServiceInstanceID> <providingServiceInstanceID> --namespace=<namespace>
 ``` 
 
-## CLI Installation
+## Installing the CLI
+To quickly get up and running with the CLI for Mac and Linux, simply execute the installer script from inside the `scripts` directory.
+```bash
+./install.sh
+```
+Or, to install a specific version: 
+```bash
+./install.sh <version>
+```
+
+## Developing the CLI
+
 ### Pre-requisites
 - Have a local Kubernetes or OpenShift cluster with mobile clients and services available via minikube, [mobile core installer](https://github.com/aerogear/mobile-core/blob/master/docs/walkthroughs/local-setup.adoc) or [minishift](https://github.com/aerogear/minishift-mobilecore-addon).
 - Install [glide](https://github.com/Masterminds/glide)
@@ -90,7 +101,7 @@ oc edit clusterrole admin # add the above and save
 oc edit clusterrole edit # add the above and save
 ```
 
-### Setup as Kubectl/OC plugin
+## Setup as Kubectl/OC plugin
 
 - have the [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) command line tool or the [oc command line tool](https://docs.openshift.org/latest/cli_reference/get_started_cli.html#installing-the-cli) already installed
 - it should be version k8s version 1.8 or OpenShift 3.7 or later

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+function usage {
+  echo "usage: ${0} [version]"
+  exit 0
+}
+
+function error_msg {
+  echo "${1}. Exit code: ${2}"
+  exit ${2}
+}
+
+function get_os {
+  case "$OSTYPE" in
+    darwin*)   
+      os="darwin" ;;
+    linux*)  
+      os="linux" ;;
+    win*)     
+      os="windows" ;;
+    *)
+      echo "Unsupported OS: $OSTYPE" 
+      exit 1 ;;
+  esac
+}
+
+function get_arch {
+  case "$(uname -m)" in 
+    x86_64) 
+      arch="amd64" ;;
+    *)
+      echo "Unsupported ARCH: $(uname -m)" 
+      exit 1 ;;
+  esac
+}
+
+function install {
+  echo "Installing the Mobile CLI..."
+  if [ -n "${1}" ]; then 
+    readonly version=${1}
+  else
+    readonly version=$(curl -s "https://api.github.com/repos/aerogear/mobile-cli/releases/latest" | grep '"tag_name":' | sed 's/[^0-9.]*//g')
+  fi
+
+  echo "Downloading version ${version}"
+  get_os
+  get_arch
+
+  curl -s -f -L -O -J https://github.com/aerogear/mobile-cli/releases/download/v${version}/mobile-cli_${version}_${os}_${arch}.tar.gz
+  exit_code=${?}
+  
+  if [ $exit_code -ne 0 ]; then 
+    error_msg "Failed to download binary" ${exit_code}
+  fi
+
+  tar -xf mobile-cli_${version}_${os}_${arch}.tar.gz && sudo cp mobile /usr/local/bin
+  exit_code=${?}
+
+  if [ $exit_code -ne 0 ]; then 
+    error_msg "Failed to unpack binary" ${exit_code}
+  fi
+
+  rm -rf mobile-cli_${version}_${os}_${arch}.tar.gz && rm -rf mobile
+  echo "Mobile CLI installed. Use 'mobile --help' for more information."
+}
+
+if [[ $* == *-h* ]] || [[ $* == *--help* ]]; then
+  usage
+fi
+
+install ${1}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,8 +16,6 @@ function get_os {
       os="darwin" ;;
     linux*)  
       os="linux" ;;
-    win*)     
-      os="windows" ;;
     *)
       echo "Unsupported OS: $OSTYPE" 
       exit 1 ;;


### PR DESCRIPTION
**Describe what this PR does and why we need it**:
Create a bash script within the mobile-cli repo to simply and quickly download and install the mobile CLI.

**Progress**
Currently does not work for Windows

**Related Jira**
[AEROGEAR-2639](https://issues.jboss.org/browse/AEROGEAR-2639)